### PR TITLE
0.1.0 release note tweaks

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -14,12 +14,12 @@ owner: MySQL
 ### Features
 New features and changes in this release:
 
-* **MySQL for Kubernetes Operator:** <%= vars.product_full %> implements the Kubernetes Operator Pattern
-  to provision and manage on-demand TanzuMySQL instances. <%= vars.product_short %> supports single-node,
-  MySQL database instances, which provide basic, high availability (HA) by using Kubernetes StatefulSets.
+* **MySQL for Kubernetes Operator:** <%= vars.product_full %> implements the Kubernetes Operator pattern
+  to provision and manage on-demand TanzuMySQL instances. <%= vars.product_short %> supports single-node
+  MySQL database instances.
   <br><br>For more information about <%= vars.product_short %> features and compatibility, see [Overview](/index.html).
   For information about <%= vars.product_short %> architecture, see [Architecture](architecture.html).
-  For more information about the Kubernetes Operator Pattern,
+  For more information about the Kubernetes Operator pattern,
   see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
 
 * **Installation Using Helm:** Kubernetes admins can use Helm to install the <%= vars.product_short %> Operator.


### PR DESCRIPTION
- We don't provide any HA yet in this release.
- "pattern" is not generally capitalized in "Operator pattern".
- No comma in "single-node MySQL database instances" (cumulative adjectives)
- I removed it anyway, but "basic high availability" are also cumulative adjectives and should not have a comma.