### PR TITLE
Update TanzuMySQL property reference for router

### DIFF
--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -64,60 +64,18 @@ To create a TanzuMySQL instance:
     secret/tanzu-mysql-image-registry created
     </pre>
 
-3. Create a `tanzumysql.yaml` file.
-   You can use the template below:
+3. Create a new YAML file to configure a TanzuMySQL instance.
 
-    ```
-    apiVersion: mysql.tanzu.vmware.com/v1alpha1
-    kind: TanzuMySQL
-    metadata:
-      name: tanzumysql-sample
-    spec:
-      storageSize: 1Gi
-      imagePullSecret: tanzu-mysql-image-registry
-
-    #### Set the storage class name to change storage class of the PVC associated with this resource
-    #  storageClassName: standard
-
-    #### Set the type of Service used to provide access to the MySQL database.
-    #  serviceType: LoadBalancer
-
-    #### Set the name of the Secret used for TLS
-    #  tls:
-    #    secret:
-    #      name: mysql-tls-secret
-
-    #### Examples to set resource limit/request for mysql/backups containers.
-
-    #  resources:
-
-    #### This is the container running the mysql server.
-    #    mysql:
-    #      limits:
-    #        cpu: 3
-    #        memory: 800Mi
-    #      requests:
-    #        cpu: 2
-    #        memory: 500Mi
-    #### This is the sidecar container that takes a backup and streams to the storage backend.
-    #    backups:
-    #      limits:
-    #        cpu: 2
-    #        memory: 500Mi
-    #      requests:
-    #        cpu: 1
-    #        memory: 200Mi
-    ```
-
-4. Edit the `tanzumysql.yaml` file.
+4. Edit your file. You can use the deployment template `tanzumysql.yaml` downloaded from TanzuNet as a reference.
    For an explanation of the properties that you can set in this file,
    see [Property Reference for tanzumysql.yml](property-reference-tanzumysql.html).
 
 5. Deploy a TanzuMySQL instance to Kubernetes by running:
 
     ```
-    kubectl -n DEVELOPMENT-NAMESPACE apply -f tanzumysql.yaml
+    kubectl -n DEVELOPMENT-NAMESPACE apply -f FILENAME
     ```
+    WHERE `FILENAME` is your file with the specific TanzuMySQL configuration
 
     For example:
 
@@ -131,7 +89,7 @@ To create a TanzuMySQL instance:
     ```
     kubectl get tanzumysql INSTANCE-NAME
     ```
-    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` in the `tanzumysql.yaml` file.
+    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` in your file
     <br><br>
     For example:
 

--- a/property-reference-tanzumysql.html.md.erb
+++ b/property-reference-tanzumysql.html.md.erb
@@ -135,7 +135,7 @@ The table below explains the properties that you can set in the `tanzumysql.yml`
   <td>No</td>
 </tr>
 <tr>
-  <td><code>spec.resources.backups</code></td>
+  <td><code>spec.resources.sidecar</code></td>
   <td>
     <ul>
       <li>limits.cpu</li>
@@ -143,9 +143,9 @@ The table below explains the properties that you can set in the `tanzumysql.yml`
     </ul>
   </td>
   <td>Best effort</td>
-  <td>Describes the maximum CPU and memory allowed for the backups container.
+  <td>Describes the maximum CPU and memory allowed for the sidecar container.
       If left blank, Kubernetes does its best effort to allocate the necessary compute resources
-      for the backups container.
+      for the sidecar container.
       For more information about CPU and memory resources,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.
@@ -154,7 +154,7 @@ The table below explains the properties that you can set in the `tanzumysql.yml`
   <td>No</td>
 </tr>
 <tr>
-  <td><code>spec.resources.backups</code></td>
+  <td><code>spec.resources.sidecar</code></td>
   <td>
     <ul>
       <li>requests.cpu</li>
@@ -162,13 +162,53 @@ The table below explains the properties that you can set in the `tanzumysql.yml`
     </ul>
   </td>
   <td>Best effort</td>
-  <td>Describes the minimum CPU and memory allowed for the backups container.
+  <td>Describes the minimum CPU and memory allowed for the sidecar container.
       If left blank, it defaults to limits if limits have been explicitly specified.
       For more information about limits, see the
       <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.
   </td>
   <td><code>requests.cpu:&nbsp;1&nbsp;, requests.memory:&nbsp;200Mi</code>
+  </td>
+  <td>No</td>
+</tr>
+<tr>
+  <td><code>spec.resources.router</code></td>
+  <td>
+    <ul>
+      <li>limits.cpu</li>
+      <li>limits.memory</li>
+    </ul>
+  </td>
+  <td>Best effort</td>
+  <td>Describes the maximum CPU and memory allowed for the router container. This container is only created when
+      <code>spec.highAvailability.enabled</code> is specified as <code>true</code>.
+      If left blank, Kubernetes does its best effort to allocate the necessary compute resources
+      for the router container.
+      For more information about CPU and memory resources,
+      see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
+      Kubernetes documentation</a>.
+  </td>
+  <td><code>limits.cpu: 1000m, limits.memory: 256Mi</code></td>
+  <td>No</td>
+</tr>
+<tr>
+  <td><code>spec.resources.router</code></td>
+  <td>
+    <ul>
+      <li>requests.cpu</li>
+      <li>requests.memory</li>
+    </ul>
+  </td>
+  <td>Best effort</td>
+  <td>Describes the minimum CPU and memory allowed for the sidecar container. This container is only created when
+      <code>spec.highAvailability.enabled</code> is specified as <code>true</code>.
+      If left blank, it defaults to limits if limits have been explicitly specified.
+      For more information about limits, see the
+      <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
+      Kubernetes documentation</a>.
+  </td>
+  <td><code>requests.cpu: 200m;, requests.memory: 48Mi</code>
   </td>
   <td>No</td>
 </tr>


### PR DESCRIPTION
This PR covers several changes:

- rename `backups` container to `sidecar`
- add new rows to property reference table for new `router` container
- simplify language when creating a TanzuMySQL instance. **This is the start of more changes to come**. I would like to guide readers to create their own files and reference our deployment templates. There are more places in the docs where we incorrectly ask them to use our deployment templates and instead they need to create/edit/manage their own YAML files.

Happy to have a discussion on the third point during the weekly docs sync.