### PR TITLE
Reference new MySQL deployment template names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We want to use placeholders consistently througout the doc.
 | REGISTRY-SERVER-URL |https://registry.pivotal.io/ |  is the TanzuNet registry or the private registry configured for your environment | create-delete.html|
 | DOCKER-PASSWORD | sample-password | credentials used to pull images from the registry | create-delete.html |
 | DOCKER-USERNAME |sample-username |  credentials used to pull images from the registry | create-delete.html |
-| INSTANCE-NAME | tanzumysql-sample and another-sample |   is the value that you configured for metadata.name in the tanzumysql.yaml file | create-delete.html, accessing.html |
-| INSTANCE-NAME-N (use instead of POD-NAME)| tanzumysql-sample-0 | "Where: + `INSTANCE-NAME` is the value that you configured for metadata.name in the tanzumysql.yaml file. + `N` is the index of the Pod in the TanzuMySQL instance." | create-delete-mysql.html, update-instance.html |
+| INSTANCE-NAME | tanzumysql-sample and another-sample |   is the value that you configured for metadata.name in the mysql.yaml deployment template | create-delete.html, accessing.html |
+| INSTANCE-NAME-N (use instead of POD-NAME)| tanzumysql-sample-0 | "Where: + `INSTANCE-NAME` is the value that you configured for metadata.name in the mysql.yaml deployment template. + `N` is the index of the Pod in the TanzuMySQL instance." | create-delete-mysql.html, update-instance.html |
 | REGISTRY-SERVER-URL |https://registry.pivotal.io/ |  is the TanzuNet registry or the private registry configured for your environment | create-delete.html|
 |

--- a/accessing.html.md.erb
+++ b/accessing.html.md.erb
@@ -100,7 +100,7 @@ To connect to the MySQL server with an external IP address:
     ```
     $ kubectl get service INSTANCE-NAME -o jsonpath={.spec.type}
     ```
-    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` in the `tanzumysql.yaml` file.
+    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` for your TanzuMySQL resource.
     <br><br>
     For example:
 
@@ -114,7 +114,7 @@ To connect to the MySQL server with an external IP address:
     ```
     $ kubectl get service INSTANCE-NAME -o jsonpath={.status.loadBalancer.ingress[].ip}
     ```
-    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` in the `tanzumysql.yaml` file.
+    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` for your TanzuMySQL resource.
     <br><br>
     For example:
 
@@ -129,7 +129,7 @@ To connect to the MySQL server with an external IP address:
     ```
     MYSQL_ROOT_PASSWORD=$(kubectl get secret INSTANCE-NAME-credentials -o go-template='{{.data.rootPassword | base64decode}}')
     ```
-    Where `INSTANCE-NAME` is the value that you configured for metadata.name in the tanzumysql.yaml file.
+    Where `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
 
 1. Log in to the MySQL server by running:
 

--- a/backup-restore.html.md.erb
+++ b/backup-restore.html.md.erb
@@ -61,38 +61,18 @@ with the location of the blobstore and the credentials to access it.
 
 To create a TanzuMySQLBackupLocation resource:
 
-1. Create a `backuplocation.yaml` file. You can use the template below:
+1. Find the `backuplocation.yaml` deployment template that you downloaded
+   in the **Tanzu MySQL Deployment Templates** TGZ file from <%= vars.product_network %>.
+   For how to download deployment templates, see [Download the Resources](install-operator.html#download)
+   in _Installing the Tanzu MySQL for Kubernetes Operator_.
 
-    ```
-    ---
-    apiVersion: mysql.tanzu.vmware.com/v1alpha1
-    kind: TanzuMySQLBackupLocation
-    metadata:
-      name: backuplocation-sample
-    spec:
-      storage:
-        # For S3 or Minio:
-        s3:
-          bucket: "name-of-bucket"
-          bucketPath: "my-backups-prefix/"
-          # region: "us-east-1"
-          endpoint:  "" # optional, default to AWS
-          forcePathStyle: false
-          disableSSL: false
-          secret:
-            name: backuplocation-sample-creds
-    ---
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: backuplocation-sample-creds
-    stringData:
-      # S3 Credentials
-      accessKeyId: "my-access-key-id"
-      secretAccessKey: "my-secret-access-key"
-    ```
+2. Create a copy of the `backuplocation.yaml` file and give it a unique name.
 
-2. Edit the `backuplocation.yaml` file with the configuration for your external blobstore.
+    For example:
+
+    <pre class="terminal">$ cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/backuplocation.yaml testbackuplocation.yaml</pre>
+
+2. Edit the file with the configuration for your external blobstore.
    For an explanation of the properties that you can set in this file,
    see [Properties for the TanzuMySQLBackupLocation Resource](property-reference-backup-restore.html#backuplocation)
    and [Properties for the Secret](property-reference-backup-restore.html#secret).
@@ -101,13 +81,14 @@ To create a TanzuMySQLBackupLocation resource:
    you want to back up by running:
 
     ```
-    kubectl apply -f backuplocation.yaml -n DEVELOPMENT-NAMESPACE
+    kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
     ```
-    Where is `DEVELOPMENT-NAMESPACE` is the namespace for the TanzuMySQL instance.
+    + Where is `DEVELOPMENT-NAMESPACE` is the namespace for the TanzuMySQL instance.
+    + Where `FILENAME` is the name of the configuration file you created in Step 2 above.
 
     For example:
 
-    <pre class="terminal">$ kubectl apply -f backuplocation.yaml -n my-namespace
+    <pre class="terminal">$ kubectl apply -f testbackuplocation.yaml -n my-namespace
     tanzumysqlbackuplocation.mysql.tanzu.vmware.com/backuplocation-sample created
     secret/backuplocation-sample-creds configured
     </pre>
@@ -142,43 +123,37 @@ To create a TanzuMySQLBackupLocation resource:
 
 To set a schedule for automatic backups, create a TanzuMySQLBackupSchedule resource:
 
-1. Create a `backupschedule.yaml` file. You can use the template below:
+1. Find the `backupschedule.yaml` deployment template that you downloaded
+   in the **Tanzu MySQL Deployment Templates** TGZ file from <%= vars.product_network %>.
+   For how to download deployment templates, see [Download the Resources](install-operator.html#download)
+   in _Installing the Tanzu MySQL for Kubernetes Operator_.
 
-    ```
-    ---
-    apiVersion: mysql.tanzu.vmware.com/v1alpha1
-    kind: TanzuMySQLBackupSchedule
-    metadata:
-      name: tanzumysqlbackupschedule-sample
-    spec:
-      backupTemplate:
-        spec:
-          location:
-            name: backuplocation-sample
-          cluster:
-            name: tanzumysql-sample
-      schedule: "@daily"
-    ```
+2. Create a copy of the `backupschedule.yaml` file and give it a unique name.
 
-2. Edit the `backupschedule.yaml` file with the name of the TanzuMySQLBackupLocation resource
+    For example:
+
+    <pre class="terminal">$ cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/backupschedule.yaml testbackupschedule.yaml</pre>
+
+2. Edit the file with the name of the TanzuMySQLBackupLocation resource
    that you created in [Create a TanzuMySQLBackupLocation Resource](backup-restore.html#create-backuplocation)
    and the name of the TanzuMySQL instance you want scheduled backups of.
    For an explanation of the properties that you can set in this file,
    see [Properties for the TanzuMySQLBackupSchedule Resource](property-reference-backup-restore.html#backupschedule).
 
-2. Create the TanzuMySQLBackupSchedule resource in the same namespace as the TanzuMySQLBackupLocation and TanzuMySQL instance that
+3. Create the TanzuMySQLBackupSchedule resource in the same namespace as the TanzuMySQLBackupLocation and TanzuMySQL instance that
    you referenced in the TanzuMySQLBackupSchedule YAML file.
 
     ```
-    kubectl apply -f backupschedule.yaml -n DEVELOPMENT-NAMESPACE
+    kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
     ```
+    Where `FILENAME` is the name of the configuration file you created in Step 2 above.
 
     For example:
-    <pre class="terminal">$ kubectl apply -f backupschedule.yaml -n my-namespace
+    <pre class="terminal">$ kubectl apply -f testbackupschedule.yaml -n my-namespace
     tanzumysqlbackupschedule.mysql.tanzu.vmware.com/backupschedule-sample created
     </pre>
 
-3. Verify that the TanzuMySQLBackupSchedule has been created by running:
+4. Verify that the TanzuMySQLBackupSchedule has been created by running:
 
     ```
     kubectl get tanzumysqlbackupschedule tanzumysqlbackupschedule-sample -o jsonpath={.spec} -n DEVELOPMENT-NAMESPACE
@@ -237,36 +212,34 @@ see [Create a TanzuMySQLBackupLocation Resource](#create-backuplocation) above.
 
 To take a backup:
 
-1. Create a `backup.yaml` file. You can use the template below:
+1. Find the `backup.yaml` deployment template that you downloaded
+   in the **Tanzu MySQL Deployment Templates** TGZ file from <%= vars.product_network %>.
+   For how to download deployment templates, see [Download the Resources](install-operator.html#download)
+   in _Installing the Tanzu MySQL for Kubernetes Operator_.
 
-    ```
-    ---
-    apiVersion: mysql.tanzu.vmware.com/v1alpha1
-    kind: TanzuMySQLBackup
-    metadata:
-      name: backup-sample
-    spec:
-      location:
-        name: backuplocation-sample
-      cluster:
-        name: tanzumysql-sample
-    ```
-
-     For an explanation of the properties that you can set in this file,
-     see [Properties for the TanzuMySQLBackup Resource](property-reference-backup-restore.html#on-demand-backup).
-
-2. Trigger the backup by creating the TanzuMySQLBackup resource in the same namespace as the instance by running:
-
-    ```
-    kubectl apply -f tanzumysqlbackup.yaml -n DEVELOPMENT-NAMESPACE
-    ```
+2. Create a copy of the `backup.yaml` file and give it a unique name.
 
     For example:
-    <pre class="terminal">$ kubectl apply -f tanzumysqlbackup.yaml -n my-namespace
+
+    <pre class="terminal">$ cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/backup.yaml testbackup.yaml</pre>
+
+3. Edit the file.
+   For an explanation of the properties that you can set for the TanzuMySQLBackup resource,
+   see [Properties for the TanzuMySQLBackup Resource](property-reference-backup-restore.html#on-demand-backup).
+
+4. Trigger the backup by creating the TanzuMySQLBackup resource in the same namespace as the instance by running:
+
+    ```
+    kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
+    ```
+    Where `FILENAME` is the name of the configuration file you created in Step 2 above.
+
+    For example:
+    <pre class="terminal">$ kubectl apply -f testbackup.yaml -n my-namespace
     tanzumysqlbackup.mysql.tanzu.vmware.com/backup-sample created
     </pre>
 
-3. Verify that a backup has been generated and track its progress by running:
+5. Verify that a backup has been generated and track its progress by running:
 
     ```
     kubectl get tanzumysqlbackup backup-sample -n DEVELOPMENT-NAMESPACE
@@ -363,7 +336,7 @@ To delete a backup:
 2. On your Kubernetes cluster, delete the TanzuMySQLBackup resource by running:
 
     ```
-    kubectl delete tanzumysqlbackup BACKUP-NAME -n DEVELOPER-NAMESPACE
+    kubectl delete tanzumysqlbackup BACKUP-NAME -n DEVELOPMENT-NAMESPACE
     ```
 
     For example:
@@ -404,42 +377,37 @@ Before you restore from a backup, you must have:
 
 To restore from a backup:
 
-1. Create a `tanzumysqlrestore.yaml` file. You can use the template below:
+1. Find the `restore.yaml` deployment template that you downloaded
+   in the **Tanzu MySQL Deployment Templates** TGZ file from <%= vars.product_network %>.
+   For how to download deployment templates, see [Download the Resources](install-operator.html#download)
+   in _Installing the Tanzu MySQL for Kubernetes Operator_.
 
-    ```
-    ---
-    apiVersion: mysql.tanzu.vmware.com/v1alpha1
-    kind: TanzuMySQLRestore
-    metadata:
-      name: tanzumysqlrestore-sample
-    spec:
-      tanzuMysqlBackup:
-        name: backup-sample
-      tanzuMysqlTemplate:
-        metadata:
-          name: tanzumysql-sample
-        spec:
-          storageSize: 1Gi
-          imagePullSecret: tanzu-mysql-image-registry
-    ```
+2. Create a copy of the `restore.yaml` file and give it a unique name.
 
-    For an explanation of the properties that you can set in this file,
-    see [Properties for the TanzuMySQLRestore Resource](property-reference-backup-restore.html#restore).
+    For example:
 
-2. Trigger the restore by creating the TanzuMySQLRestore resource in the same namespace
+    <pre class="terminal">$ cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/restore.yaml testrestore.yaml</pre>
+
+
+3. Edit the file.
+   For information about the properties that you can set for the TanzuMySQLRestore resource,
+   see [Property Reference for Backup and Restore](property-reference-backup-restore.html#restore).
+
+4. Trigger the restore by creating the TanzuMySQLRestore resource in the same namespace
    as the TanzuMySQLBackup and TanzuMySQLBackupLocation by running:
 
     ```
-    kubectl apply -f tanzumysqlrestore.yaml -n DEVELOPMENT-NAMESPACE
+    kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
     ```
+    Where `FILENAME` is the name of the configuration file you created in Step 2 above.
 
     For example:
     <pre  class="terminal">
-    $ kubectl apply -f tanzumysqlrestore.yaml -n my-namespace
+    $ kubectl apply -f testrestore.yaml -n my-namespace
     tanzumysqlrestore.mysql.tanzu.vmware.com/tanzumysqlrestore-sample created
     </pre>
 
-3. Verify that a restore has been triggered and track the progress of your restore by running:
+5. Verify that a restore has been triggered and track the progress of your restore by running:
 
     ```
     kubectl get tanzumysqlrestore tanzumysqlrestore-sample -n DEVELOPMENT-NAMESPACE
@@ -452,7 +420,7 @@ To restore from a backup:
     tanzumysqlrestore-sample   Succeeded   2020-12-01T21:52:30.000000Z   2020-12-01T21:53:09.163336Z   13m
    </pre>
 
-4. To understand the output, see the table below:
+6. To understand the output, see the table below:
     <table class="nice">
     <col width="20%">
     <col width="80%">

--- a/configure-tls.html.md.erb
+++ b/configure-tls.html.md.erb
@@ -28,7 +28,7 @@ This topic describes two methods:
 * Using cert-manager.
   See [Create TLS Secret with cert-manager](#using-cert-manager) below.
 
-After creating the secret, you add the name of the secret to the `tanzumysql.yaml` file,
+After creating the secret, you add the name of the secret to your copy of the `mysql.yaml` file,
 and configure the instance with the updated file, as described in
 [Configure TanzuMySQL for TLS](#use-tls) below.
 
@@ -144,14 +144,18 @@ For information about installing Helm, see the
 
 To configure TLS for the TanzuMySQL instance:
 
-1. In the `tanzumysql.yaml` for the TanzuMySQL instance, specify `spec.tls.secret.name` as the name
+1. In your copy of the `mysql.yaml` for the TanzuMySQL instance, specify `spec.tls.secret.name` as the name
 of the TLS Secret created in the namespace.
 
 2. Create or update the TanzuMySQL instance by running:
 
     ```
-    kubectl apply -f tanzumysql.yaml
+    kubectl apply -f FILENAME -n DEVELOPMENT_NAMESPACE
     ```
+    Where:
+    +  `FILENAME` is the name of the configuration file for your TanzuMySQL resource.
+    +  `DEVELOPMENT-NAMESPACE` is the namespace for the TanzuMySQL instance.
+
 
 
 ## <a id='use-tls'></a>Connect to TanzuMySQL over TLS

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -64,23 +64,23 @@ To create a TanzuMySQL instance:
     secret/tanzu-mysql-image-registry created
     </pre>
 
-3. Find the `tanzumysql.yaml` deployment template that you downloaded
+3. Find the `mysql.yaml` deployment template that you downloaded
    in the **Tanzu MySQL Deployment Templates** TGZ file from <%= vars.product_network %>.
    For how to download deployment templates, see [Download the Resources](install-operator.html#download)
    in _Installing the Tanzu MySQL for Kubernetes Operator_.
 
-4. Create a copy of the `tanzumysql.yaml` file and give it a unique name.
+4. Create a copy of the `mysql.yaml` file and give it a unique name.
 
     For example:
 
-    <pre class="terminal">$ cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/tanzumysql.yaml testdb.yaml</pre>
+    <pre class="terminal">$ cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/mysql.yaml testdb.yaml</pre>
 
 
 5. Edit the file.
-   For information about the properties that you can set in this file,
+   For information about the properties that you can set for the TanzuMySQL resource,
    see [Property Reference for tanzumysql.yml](property-reference-tanzumysql.html).
 
-5. Deploy a TanzuMySQL instance to Kubernetes by running:
+6. Deploy a TanzuMySQL instance to Kubernetes by running:
 
     ```
     kubectl -n DEVELOPMENT-NAMESPACE apply -f FILENAME
@@ -94,16 +94,16 @@ To create a TanzuMySQL instance:
     </pre>
 
 
-6. Verify that the instance was created successfully by running:
+7. Verify that the instance was created successfully by running:
 
     ```
-    kubectl get tanzumysql INSTANCE-NAME
+    kubectl -n DEVELOPMENT-NAMESPACE get tanzumysql INSTANCE-NAME
     ```
     Where `INSTANCE-NAME` is the value that you configured for `metadata.name` in your file
     <br><br>
     For example:
 
-    <pre class="terminal">$ kubectl get tanzumysql tanzumysql-sample
+    <pre class="terminal">$ kubectl -n my-namespace get tanzumysql tanzumysql-sample
 NAME                READY   STATUS    AGE
 tanzumysql-sample   true    Running   2m17s
     </pre>

--- a/property-reference-backup-restore.html.md.erb
+++ b/property-reference-backup-restore.html.md.erb
@@ -21,7 +21,7 @@ see [Backing Up and Restoring in Tanzu MySQL for Kubernetes](backup-restore.html
 
 ##<a name="backuplocation"></a> Properties for the TanzuMySQLBackupLocation Resource
 
-The table below explains the properties that can be set in the `backuplocation.yaml` file.
+The table below explains the properties that can be set for the TanzuMySQLBackupLocation resource.
 
 <table style="width:1000px" class="nice">
 <col width="10%">
@@ -162,8 +162,7 @@ The table below explains the properties that can be set in the `secret` for the 
 
 ##<a name="backupschedule"></a> Properties for the TanzuMySQLBackupSchedule Resource
 
-The table below explains the properties that can be set in the `backupschedule.yaml` file
-for TanzuMySQLBackupSchedule resource.
+The table below explains the properties that can be set for the TanzuMySQLBackupSchedule resource.
 <table style="width:1000px" class="nice">
 <col width="10%">
 <col width="15%">
@@ -217,8 +216,7 @@ for TanzuMySQLBackupSchedule resource.
 
 ##<a name="on-demand-backup"></a> Properties for the TanzuMySQLBackup Resource
 
-The table below explains the properties that can be set in the `backup.yaml` file
-for the TanzuMySQLBackup resource.
+The table below explains the properties that can be set for the TanzuMySQLBackup resource.
 
 [//]: # ( MISSING EXAMPLES)
 
@@ -269,8 +267,7 @@ for the TanzuMySQLBackup resource.
 
 ##<a name="restore"></a> Properties for the TanzuMySQLRestore Resource
 
-The table below explains the properties that can be set in the `tanzumysqlrestore.yaml` file
-for the TanzuMySQLRestore resource.
+The table below explains the properties that can be set for the TanzuMySQLRestore resource.
 
 
 <table style="width:1000px" class="nice">

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -45,7 +45,7 @@ To scale `storageSize`:
     kubectl get pvc mysql-data-INSTANCE-NAME-N -o jsonpath={.spec.storageClassName}
     ```
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name in the tanzumysql.yaml file.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
     + `N` is the index of the Pod in the TanzuMySQL instance.
 
     For example:
@@ -88,7 +88,7 @@ To scale `storageSize`:
     '{"spec": {"resources": {"requests": {"storage": "NEW-REQUESTED-SIZE"}}}}'
     ```
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name in the tanzumysql.yaml file.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
     + `N` is the index of the Pod in the TanzuMySQL instance.
     + `NEW-REQUESTED-SIZE` is the increased volume size.
 
@@ -117,7 +117,7 @@ has successfully restarted, verify that the storage has been resized.
     kubectl exec INSTANCE-NAME-N -c mysql -- df -h /var/lib/mysql
     ```
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name in the tanzumysql.yaml file.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
     + `N` is the index of the Pod in the TanzuMySQL instance.
 
     For example:
@@ -148,7 +148,7 @@ You can use one of these methods to update the configuration:
     ```
 
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name in the tanzumysql.yaml file.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
     + `MYSQL-RESOURCES` is a collection of `cpu` and `memory` limits and requests for the MySQL container.
     + `BACKUP-RESOURCES` is a collection of `cpu` and `memory` limits and requests for the sidecar container.
 
@@ -161,7 +161,7 @@ You can use one of these methods to update the configuration:
     change the fields in the file and apply the changes.
 
     For example:
-    <pre class="terminal">$ kubectl apply -f tanzumysql.yaml</pre>
+    <pre class="terminal">$ kubectl apply -f mysql.yaml</pre>
 
 For more information on managing CPU and Memory resources, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 
@@ -189,7 +189,7 @@ update the TanzuMySQL configuration by one of the methods below:
     kubectl patch tanzumysql INSTANCE-NAME -p '{"spec": {"PROPERTY": "VALUE"}}'
     ```
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name in the tanzumysql.yaml file.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
     + `PROPERTY` is the property name.
     + `VALUE` is the new property value.
 
@@ -200,4 +200,4 @@ update the TanzuMySQL configuration by one of the methods below:
     change the fields in the file and apply the changes.
 
     For example:
-    <pre class="terminal">$ kubectl apply -f tanzumysql.yaml</pre>
+    <pre class="terminal">$ kubectl apply -f mysql.yaml</pre>


### PR DESCRIPTION
Reference new MySQL deployment template names and introduce pattern of having the reader copy the deployment
template rather than edit it directly.

New names:
- mysql.yaml
- backup.yaml
- restore.yaml
- backuplocation.yaml
- backupschedule.yaml

[#176827702](https://www.pivotaltracker.com/story/show/176827702)


Name the branches to merge this change with or enter "None". **None**
