### PR TITLE
Rename CRDs and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ This is a word list for terminology and word usage specific to the VMware Tanzu 
 | admin | Use as a person's job description instead of operator. Decided: JD, Kim Bassett, and David Sharp 2020.12.09 and changed to admin because that's our house style. If this specifically refers to the Kubernetes admin, use "Kubernetes admin" in first use on the page. |
 | Kubernetes admin | See "admin" above. |
 | Operator | Don't use as a job description for a person. Use as the "Tanzu MySQL Operator" or "Kubernetes Operator". Decided: 2020.12.10 Judy explained that the Tanzu MySQL Operator is a more precise term than the Kubernetes operator. The Tanzu MySQL Operator is a type of Kubernetes Operator. Use the capital "O" and in the first use on the page, preface with "Kubernetes" or something similar to show that it's a pattern and not a person.|
-| Pod  | From the [word list](https://docs.google.com/spreadsheets/d/1hkadtxR1hY57kK7h5HN4ITHLJleZixCDH_RJPUpNq_A/edit?usp=sharing) See "TanzuMySQL Pod" below. |
+| Pod  | From the [word list](https://docs.google.com/spreadsheets/d/1hkadtxR1hY57kK7h5HN4ITHLJleZixCDH_RJPUpNq_A/edit?usp=sharing) See "MySQL Pod" below. |
 | persistent volume claim (PVC)  | Spell out on first use on page.|
-| TanzuMySQL instance  | Use this phrase consistently. Okay to shorten it to "instance". Not okay to use "MySQL instance" or "Tanzu instance" or "database instance". "TanzuMySQL" is a _kind_ in Kubernetes so that it the precise term. Decided: JD, Kim Bassett, and David Sharp 2020.12.09.|
-| TanzuMySQL Pod | Usually use this instead of just Pod. Decided: 2020.12.10 Judy and Jane |
+| MySQL instance  | Use this phrase consistently. Okay to shorten it to "instance". Not okay to use "Tanzu instance" or "database instance". "MySQL" is a _kind_ in Kubernetes so that it the precise term. Decided: JD, Kim Bassett, and David Sharp 2020.12.09. Changed TanzuMySQL -> MySQL (Shaan 2021.02.24)|
+| MySQL Pod | Usually use this instead of just Pod. Decided: 2020.12.10 Judy and Jane |
 | `.yaml` | Instead of `.yml` |
 
 ## Placeholder Table
@@ -46,7 +46,7 @@ We want to use placeholders consistently througout the doc.
 | REGISTRY-SERVER-URL |https://registry.pivotal.io/ |  is the TanzuNet registry or the private registry configured for your environment | create-delete.html|
 | DOCKER-PASSWORD | sample-password | credentials used to pull images from the registry | create-delete.html |
 | DOCKER-USERNAME |sample-username |  credentials used to pull images from the registry | create-delete.html |
-| INSTANCE-NAME | tanzumysql-sample and another-sample |   is the value that you configured for metadata.name in the mysql.yaml deployment template | create-delete.html, accessing.html |
-| INSTANCE-NAME-N (use instead of POD-NAME)| tanzumysql-sample-0 | "Where: + `INSTANCE-NAME` is the value that you configured for metadata.name in the mysql.yaml deployment template. + `N` is the index of the Pod in the TanzuMySQL instance." | create-delete-mysql.html, update-instance.html |
+| INSTANCE-NAME | mysql-sample and another-sample |   is the value that you configured for metadata.name in the mysql.yaml deployment template | create-delete.html, accessing.html |
+| INSTANCE-NAME-N (use instead of POD-NAME)| mysql-sample-0 | "Where: + `INSTANCE-NAME` is the value that you configured for metadata.name in the mysql.yaml deployment template. + `N` is the index of the Pod in the MySQL instance." | create-delete-mysql.html, update-instance.html |
 | REGISTRY-SERVER-URL |https://registry.pivotal.io/ |  is the TanzuNet registry or the private registry configured for your environment | create-delete.html|
 |

--- a/accessing.html.md.erb
+++ b/accessing.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Accessing a TanzuMySQL Instance
+title: Accessing a MySQL Instance
 owner: MySQL
 ---
 <% current_page.data.title = "Accessing a " + vars.product_short + " Instance" %>
@@ -36,7 +36,7 @@ To see all MySQL server settings configured:
     For example:
 
     <pre class="terminal">
-    $ kubectl -n my-namespace exec --stdin --tty pod/tanzumysql-sample-0 -- /bin/bash
+    $ kubectl -n my-namespace exec --stdin --tty pod/mysql-sample-0 -- /bin/bash
     </pre>
 
 1. Review the configuration files named `/etc/mysql/conf.d/base.cnf` and `/etc/mysql/conf.d/autotune.cnf`.
@@ -57,7 +57,7 @@ To connect to the MySQL server:
     For example:
 
     <pre class="terminal">
-    $ kubectl -n my-namespace exec --stdin --tty pod/tanzumysql-sample-0 -- /bin/bash
+    $ kubectl -n my-namespace exec --stdin --tty pod/mysql-sample-0 -- /bin/bash
     </pre>
 
 1. Log in to the MySQL server by running:
@@ -84,15 +84,15 @@ To connect to the MySQL server with an external IP address:
 1. Create or update the <%= vars.product_short %> instance using the <code>LoadBalancer</code> ServiceType.
     <br><br>
     For more information about how to create the <%= vars.product_short %> instance, see
-    [Create a TanzuMySQL Instance](./create-delete-mysql.html#create-instance).
+    [Create a MySQL Instance](./create-delete-mysql.html#create-instance).
     For more information about how to update the <%= vars.product_short %> instance or change the ServiceType,
-    see [Updating a TanzuMySQL Instance](./update-instance.html).
+    see [Updating a MySQL Instance](./update-instance.html).
 
     <p class="note">
       <strong>Note:</strong> You must do this before you can connect to a
       <%= vars.product_short %> instance off-platform.
       For more information about how to specify the property to create the correct service, see
-      <a href="./property-reference-tanzumysql.html">Property Reference for the TanzuMySQL Resource</a>.
+      <a href="./property-reference-mysql.html">Property Reference for the MySQL Resource</a>.
     </p>
 
 1. Verify the ServiceType is `LoadBalancer` instead of the default `ClusterIP`:
@@ -100,12 +100,12 @@ To connect to the MySQL server with an external IP address:
     ```
     $ kubectl get service INSTANCE-NAME -o jsonpath={.spec.type}
     ```
-    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` for your TanzuMySQL resource.
+    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` for your MySQL resource.
     <br><br>
     For example:
 
     <pre class="terminal">
-    $ kubectl get service tanzumysql-sample -o jsonpath={.spec.type}
+    $ kubectl get service mysql-sample -o jsonpath={.spec.type}
     LoadBalancer
     </pre>
 
@@ -114,22 +114,22 @@ To connect to the MySQL server with an external IP address:
     ```
     $ kubectl get service INSTANCE-NAME -o jsonpath={.status.loadBalancer.ingress[].ip}
     ```
-    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` for your TanzuMySQL resource.
+    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` for your MySQL resource.
     <br><br>
     For example:
 
     <pre class="terminal">
-    $ kubectl get service tanzumysql-sample -o jsonpath={.status.loadBalancer.ingress[].ip}
+    $ kubectl get service mysql-sample -o jsonpath={.status.loadBalancer.ingress[].ip}
     a4dc8de1biefe13112-17761231.us-west-2.elb.amazonaws.com
     </pre>
 
 1. Get the root password. The root user password is available in the Kubernetes Secret named after
-   the TanzuMySQL instance suffixed with `-credentials`:
+   the MySQL instance suffixed with `-credentials`:
 
     ```
     MYSQL_ROOT_PASSWORD=$(kubectl get secret INSTANCE-NAME-credentials -o go-template='{{.data.rootPassword | base64decode}}')
     ```
-    Where `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
+    Where `INSTANCE-NAME` is the value that you configured for metadata.name for your MySQL resource.
 
 1. Log in to the MySQL server by running:
 
@@ -167,7 +167,7 @@ To disable off-platform connections:
 To connect to the MySQL server with the Kubernetes API server:
 
 1. Get the root password. The root user password is available in the Kubernetes Secret named after
-  the TanzuMySQL instance suffixed with `-credentials`.
+  the MySQL instance suffixed with `-credentials`.
 
     ```
     MYSQL_ROOT_PASSWORD=$(kubectl get secret INSTANCE-NAME-credentials -o go-template='{{.data.rootPassword | base64decode}}')
@@ -184,7 +184,7 @@ about the command, see [Kubernetes documentation](https://kubernetes.io/docs/ref
     For example:
 
     <pre class="terminal">
-    $ kubectl port-forward service/tanzumysql-sample 3306 &
+    $ kubectl port-forward service/mysql-sample 3306 &
     <br>Forwarding from 127.0.0.1:3306 -> 3306
     Forwarding from [::1]:3306 -> 3306
     </pre>
@@ -202,7 +202,7 @@ the MySQL client:
 
     <pre class="terminal">
     $ jobs
-    [1]+  Running    kubectl port-forward service/tanzumysql-sample 3306 & <br>
+    [1]+  Running    kubectl port-forward service/mysql-sample 3306 & <br>
     $ kill %1
     </pre>
 
@@ -212,12 +212,12 @@ the MySQL client:
 The name of the Service is the same as the name of the <%= vars.product_short %> instance.
 
 If the app is deployed on the Kubernetes cluster, it can access the MySQL server using the DNS name
-of the TanzuMySQL service.
+of the MySQL service.
 This DNS name is only resolvable within the Kubernetes cluster.
 
 To connect an app to the MySQL server:
 
-1. If the app is deployed outside the Kubernetes cluster, enable the TanzuMySQL service to be
+1. If the app is deployed outside the Kubernetes cluster, enable the MySQL service to be
 externally routable through a load balancer by following the
 [Connect to the MySQL Server with an External IP Address](#off-platform-access) procedure above.
 
@@ -239,8 +239,8 @@ See the following example of setting up <%= vars.product_short %> with a databas
 can use with the Wordpress Helm chart:
 
 <pre class="terminal">
-$ kubectl exec -it tanzumysql-sample-0 -c mysql -- bash
-mysql@tanzumysql-sample-0:/$ mysql -p$(cat $MYSQL_ROOT_PASSWORD_FILE) -u root
+$ kubectl exec -it mysql-sample-0 -c mysql -- bash
+mysql@mysql-sample-0:/$ mysql -p$(cat $MYSQL_ROOT_PASSWORD_FILE) -u root
 mysql> CREATE DATABASE bitnami_wordpress;
 Query OK, 1 row affected (0.20 sec)
 
@@ -254,7 +254,7 @@ mysql> FLUSH PRIVILEGES;
 Query OK, 0 rows affected (0.10 sec)
 </pre>
 
-Next, the DNS name of the TanzuMySQL service is passed in to the chart as the value of
+Next, the DNS name of the MySQL service is passed in to the chart as the value of
 `externalDatabase.host`:
 
 <pre class="terminal">
@@ -262,7 +262,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 "bitnami" has been added to your repositories<br>
 $ helm install wp bitnami/wordpress \
     --set mariadb.enabled=false \
-    --set externalDatabase.host=tanzumysql-sample.default.svc.cluster.local \
+    --set externalDatabase.host=mysql-sample.default.svc.cluster.local \
     --set externalDatabase.password=hunter2
 NAME: wp
 LAST DEPLOYED: Tue Dec 8 14:32:08 2020

--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -22,29 +22,29 @@ The diagram below shows the architecture of <%= vars.product_short %>:
 <%= vars.product_short %> provides extensions to the Kubernetes API through custom resources.
 The product provides five separate custom resources:
 
-+ [TanzuMySQL](#mysql): A managed MySQL instance
-+ [TanzuMySQLBackupLocation](#mysqlbackuplocation): Defines an S3 storage bucket for backups
-+ [TanzuMySQLBackup](#mysqlbackup): Requests for a backup
-+ [TanzuMySQLBackupSchedule](#mysqlbackupschedule): Defines a backup schedule
-+ [TanzuMySQLRestore](#mysqlrestore): Requests to restore data
++ [MySQL](#mysql): A managed MySQL instance
++ [MySQLBackupLocation](#mysqlbackuplocation): Defines an S3 storage bucket for backups
++ [MySQLBackup](#mysqlbackup): Requests for a backup
++ [MySQLBackupSchedule](#mysqlbackupschedule): Defines a backup schedule
++ [MySQLRestore](#mysqlrestore): Requests to restore data
 
-###<a id="mysql"></a> TanzuMySQL
+###<a id="mysql"></a> MySQL
 
 Applying this resource causes the Kubernetes Operator to create a StatefulSet with a single Pod
 with two containers.
 One container runs the MySQL database software, and the other runs components to support backups.
 
-The TanzuMySQL Pod mounts a Persistent Volume Claim (PVC) which holds the MySQL data.
+The MySQL Pod mounts a Persistent Volume Claim (PVC) which holds the MySQL data.
 
-When a TanzuMySQL instance is created, the Tanzu MySQL Operator automatically creates a Kubernetes service
-with a service type of `ClusterIP` which routes connections to the TanzuMySQL Pod.
+When a MySQL instance is created, the Tanzu MySQL Operator automatically creates a Kubernetes service
+with a service type of `ClusterIP` which routes connections to the MySQL Pod.
 
   ```
   ---
-  apiVersion: mysql.tanzu.vmware.com/v1alpha1
-  kind: TanzuMySQL
+  apiVersion: sql.tanzu.vmware.com/v1alpha1
+  kind: MySQL
   metadata:
-    name: tanzumysql-sample
+    name: mysql-sample
   spec:
     resources:
       mysql:
@@ -55,37 +55,37 @@ with a service type of `ClusterIP` which routes connections to the TanzuMySQL Po
   ```
 
 After applying this resource, the Operator creates
-the low-level Kubernetes resources to run this TanzuMySQL instance.
+the low-level Kubernetes resources to run this MySQL instance.
 
 You can see the status of the instance by running:
 
 ```
-kubectl get tanzumysqls.mysql.tanzu.vmware.com
+kubectl get mysqls.sql.tanzu.vmware.com
 ```
 
 Initially, this instance is in a pending state:
 
 <pre class="terminal">
-$ kubectl get tanzumysqls.mysql.tanzu.vmware.com
-NAME                READY   STATUS    AGE
-tanzumysql-sample           Pending   2s
+$ kubectl get mysqls.sql.tanzu.vmware.com
+NAME           READY   STATUS    AGE
+mysql-sample           Pending   2s
 </pre>
 
 Later, the instance transitions to a running state:
 
 <pre class="terminal">
-$ kubectl get tanzumysqls.mysql.tanzu.vmware.com
-NAME                READY   STATUS    AGE
-tanzumysql-sample   true    Running   27s
+$ kubectl get mysqls.sql.tanzu.vmware.com
+NAME           READY   STATUS    AGE
+mysql-sample   true    Running   27s
 </pre>
 
-### <a id="mysqlbackuplocation"></a> TanzuMySQLBackupLocation
+### <a id="mysqlbackuplocation"></a> MySQLBackupLocation
 
 This resource describes metadata and credentials for storing backups in an S3-compatible object store.
 
-TanzuMySQLBackup resources reference this backup location to know where to save backup artifacts.
-The Operator creates or maintains a TanzuMySQLBackup resource for every artifact found in the backup location.
-Consequently, creating a TanzuMySQLBackupLocation that contains existing artifacts generates new, corresponding TanzuMySQLBackup resources.
+MySQLBackup resources reference this backup location to know where to save backup artifacts.
+The Operator creates or maintains a MySQLBackup resource for every artifact found in the backup location.
+Consequently, creating a MySQLBackupLocation that contains existing artifacts generates new, corresponding MySQLBackup resources.
 
   ```
   ---
@@ -98,8 +98,8 @@ Consequently, creating a TanzuMySQLBackupLocation that contains existing artifac
     accessKeyId: "my-s3-access-key-id"
     secretAccessKey: "my-s3-secret-access-key"
   ---
-  apiVersion: mysql.tanzu.vmware.com/v1alpha1
-  kind: TanzuMySQLBackupLocation
+  apiVersion: sql.tanzu.vmware.com/v1alpha1
+  kind: MySQLBackupLocation
   metadata:
     name: backuplocation-sample
   spec:
@@ -117,99 +117,99 @@ Consequently, creating a TanzuMySQLBackupLocation that contains existing artifac
   ```
 
 Credentials for S3 are stored in a Kubernetes secret with the keys `accessKeyId`, `secretAccessKey`.
-TanzuMySQLBackupLocation resources do not currently have any associated status,
+MySQLBackupLocation resources do not currently have any associated status,
 but you can list them using kubectl.
 For example:
 
 <pre class='terminal'>
-$ kubectl get tanzumysqlbackuplocations.mysql.tanzu.vmware.com
+$ kubectl get mysqlbackuplocations.sql.tanzu.vmware.com
 NAME                    AGE
 backuplocation-sample   2m38s
 </pre>
 
-### <a id='mysqlbackup'></a> TanzuMySQLBackup
+### <a id='mysqlbackup'></a> MySQLBackup
 
 This resource triggers the instance to run the Percona XtraBackup utility and
 upload a backup artifact to the blobstore.
-Blobstore artifacts are represented as TanzuMySQLBackup resources for subsequent restore.
+Blobstore artifacts are represented as MySQLBackup resources for subsequent restore.
 The resource requests for a backup to be taken as soon as possible.
 For a resource that requests a scheduled backup,
-see [TanzuMySQLBackupSchedule](#mysqlbackupschedule) below.
+see [MySQLBackupSchedule](#mysqlbackupschedule) below.
 For example:
 
 ```
 ---
-apiVersion: mysql.tanzu.vmware.com/v1alpha1
-kind: TanzuMySQLBackup
+apiVersion: sql.tanzu.vmware.com/v1alpha1
+kind: MySQLBackup
 metadata:
   name: backup-sample
 spec:
   location:
     name: backuplocation-sample
   cluster:
-    name: tanzumysql-sample
+    name: mysql-sample
 ```
 
 You can see the status of the backup using kubectl.
 For example:
 
 <pre class='terminal'>
-$ kubectl get tanzumysqlbackups.mysql.tanzu.vmware.com
+$ kubectl get mysqlbackups.sql.tanzu.vmware.com
 NAME            STATUS      TIME SCHEDULED                TIME STARTED                  TIME COMPLETED                AGE
 backup-sample   Succeeded   2020-12-07T15:52:12.065092Z   2020-12-07T15:52:12.279522Z   2020-12-07T15:52:16.041156Z   8s
 </pre>
 
-###<a id="mysqlbackupschedule"></a> TanzuMySQLBackupSchedule
+###<a id="mysqlbackupschedule"></a> MySQLBackupSchedule
 
-This resource defines a schedule to automatically create TanzuMySQLBackup resources.
+This resource defines a schedule to automatically create MySQLBackup resources.
 For example:
 
 ```
 ---
-apiVersion: mysql.tanzu.vmware.com/v1alpha1
-kind: TanzuMySQLBackupSchedule
+apiVersion: sql.tanzu.vmware.com/v1alpha1
+kind: MySQLBackupSchedule
 metadata:
-  name: tanzumysqlbackupschedule-sample
+  name: mysqlbackupschedule-sample
 spec:
   backupTemplate:
     spec:
       location:
         name: backuplocation-sample
       cluster:
-        name: tanzumysql-sample
+        name: mysql-sample
   schedule: "@daily"
 ```
 
-TanzuMySQLBackupSchedule resources do not currently have any associated status,
+MySQLBackupSchedule resources do not currently have any associated status,
 but you can list them using kubectl.
 For example:
 
 <pre class='terminal'>
-$ kubectl get tanzumysqlbackupschedules.mysql.tanzu.vmware.com
-NAME                              AGE
-tanzumysqlbackupschedule-sample   8s
+$ kubectl get mysqlbackupschedules.sql.tanzu.vmware.com
+NAME                         AGE
+mysqlbackupschedule-sample   8s
 </pre>
 
-###<a id="mysqlrestore"></a> TanzuMySQLRestore
+###<a id="mysqlrestore"></a> MySQLRestore
 
-This resource instructs the Operator to create a new PVC and a new TanzuMySQL instance
-from an existing TanzuMySQLBackup resource.
-The backup artifact for the TanzuMySQLBackup resource is loaded into the new PVC
+This resource instructs the Operator to create a new PVC and a new MySQL instance
+from an existing MySQLBackup resource.
+The backup artifact for the MySQLBackup resource is loaded into the new PVC
 before the MySQL database is started.
 For example:
 
 ```
 ---
-apiVersion: mysql.tanzu.vmware.com/v1alpha1
-kind: TanzuMySQLRestore
+apiVersion: sql.tanzu.vmware.com/v1alpha1
+kind: MySQLRestore
 metadata:
-  name: tanzumysqlrestore-sample
+  name: mysqlrestore-sample
 spec:
-  tanzuMysqlBackup:
+  mysqlBackup:
     name: backup-sample
-  tanzuMysqlTemplate:
+  mysqlTemplate:
     metadata:
-      name: tanzumysql-sample
+      name: mysql-sample
     spec:
       storageSize: 1Gi
       imagePullSecret: tanzu-mysql-image-registry
@@ -219,28 +219,28 @@ You can see the status of the restore using kubectl.
 For example:
 
 <pre class='terminal'>
-$ kubectl get tanzumysqlrestores.mysql.tanzu.vmware.com
-NAME                       STATUS    TIME STARTED                  TIME COMPLETED   AGE
-tanzumysqlrestore-sample   Running   2020-12-07T15:56:26.000000Z                    10s
+$ kubectl get mysqlrestores.sql.tanzu.vmware.com
+NAME                  STATUS    TIME STARTED                  TIME COMPLETED   AGE
+mysqlrestore-sample   Running   2020-12-07T15:56:26.000000Z                    10s
 </pre>
 
-The restore retrieves and unpacks the backup artifact and creates the TanzuMySQL instance.
+The restore retrieves and unpacks the backup artifact and creates the MySQL instance.
 The restore time is proportional to the size of the backup artifact.
 For example:
 
 <pre class='terminal'>
-$ kubectl get tanzumysqlrestores.mysql.tanzu.vmware.com
-NAME                       STATUS      TIME STARTED                  TIME COMPLETED                AGE
-tanzumysqlrestore-sample   Succeeded   2020-12-07T15:56:26.000000Z   2020-12-07T15:56:41.765479Z   20s
+$ kubectl get mysqlrestores.sql.tanzu.vmware.com
+NAME                  STATUS      TIME STARTED                  TIME COMPLETED                AGE
+mysqlrestore-sample   Succeeded   2020-12-07T15:56:26.000000Z   2020-12-07T15:56:41.765479Z   20s
 </pre>
 
 
-At the end of the restore process, you have a TanzuMySQL instance with the `READY` state `true`
+At the end of the restore process, you have a MySQL instance with the `READY` state `true`
 and with `STATUS` `running`.
 For example:
 
 <pre class='terminal'>
-$ kubectl get tanzumysqls.mysql.tanzu.vmware.com
-NAME                READY   STATUS    AGE
-tanzumysql-sample   true    Running   30s
+$ kubectl get mysqls.sql.tanzu.vmware.com
+NAME           READY   STATUS    AGE
+mysql-sample   true    Running   30s
 </pre>

--- a/backup-restore.html.md.erb
+++ b/backup-restore.html.md.erb
@@ -8,7 +8,7 @@ This topic describes how to back up and restore <%= vars.product_full %>.
 ## <a id="overview"></a> Overview
 
 <%= vars.product_short %> allows you to generate on-demand backups,
-configure schedules for automated backups, and restore backups to new TanzuMySQL instances.
+configure schedules for automated backups, and restore backups to new MySQL instances.
 
 For uploading and retrieving backup artifacts,
 <%= vars.product_short %> currently supports S3, Minio, and other S3-compatible storage.
@@ -16,18 +16,18 @@ For uploading and retrieving backup artifacts,
 For backing up and restoring,
 <%= vars.product_short %> uses four of the five Custom Resource Definitions (CRDs):
 
-  * **TanzuMySQLBackup:** References a TanzuMySQL backup artifact that exists in an
-    external blobstore such as S3 or Minio. A new TanzuMySQLBackup resource is created
+  * **MySQLBackup:** References a MySQL backup artifact that exists in an
+    external blobstore such as S3 or Minio. A new MySQLBackup resource is created
     every time an on-demand or scheduled backup is generated.
 
-  * **TanzuMySQLBackupLocation:** References an external blobstore and credentials
+  * **MySQLBackupLocation:** References an external blobstore and credentials
     necessary to access the blobstore.
 
-  * **TanzuMySQLBackupSchedule:** Represents a CronJob schedule on which to perform
+  * **MySQLBackupSchedule:** Represents a CronJob schedule on which to perform
     backups.
 
-  * **TanzuMySQLRestore:** References an instance of a restore that was performed.
-    A new TanzuMySQLRestore resource is created every time a restore is performed.
+  * **MySQLRestore:** References an instance of a restore that was performed.
+    A new MySQLRestore resource is created every time a restore is performed.
 
 For detailed information about the CRDs,
 see [Controllers and Custom Resource Definitions (CRDs)](architecture.html#controllers-crds)
@@ -35,31 +35,31 @@ in _Tanzu MySQL for Kubernetes Architecture_.
 
 ##<a id="sync-of-backups"></a> About Synchronization of Backups with the External Blobstore
 
-<%= vars.product_short %> syncs TanzuMySQLBackup resources in a Kubernetes cluster with the
+<%= vars.product_short %> syncs MySQLBackup resources in a Kubernetes cluster with the
 contents of the external blobstore.
 The external blobstore is treated as the source of truth.
-This means that, if a `TanzuMySQLBackup` resource is deleted on the Kubernetes cluster, but the
+This means that, if a `MySQLBackup` resource is deleted on the Kubernetes cluster, but the
 associated backup artifact still exists in the external blobstore, <%= vars.product_short %>
-re-creates the `TanzuMySQLBackup` resource to match the contents of the external
+re-creates the `MySQLBackup` resource to match the contents of the external
 blobstore.
 
 ##<a id="backup"></a> Back Up <%= vars.product_short %> Data
 
-Performing backups for <%= vars.product_short %> requires creating a TanzuMySQLBackupLocation resource
+Performing backups for <%= vars.product_short %> requires creating a MySQLBackupLocation resource
 that references an external blobstore.
-Both on-demand backups and scheduled backups use the TanzuMySQLBackupLocation to upload
+Both on-demand backups and scheduled backups use the MySQLBackupLocation to upload
 backup artifacts to the external blobstore.
 
 Before starting the procedures for backing up a <%= vars.product_short %> instance,
 ensure that you know the configuration details of your external blobstore and how often
 you want to perform scheduled backups.
 
-###<a id="create-backuplocation"></a> Create a TanzuMySQLBackupLocation Resource
+###<a id="create-backuplocation"></a> Create a MySQLBackupLocation Resource
 
-The purpose of creating this TanzuMySQLBackupLocation Resource is to configure the namespace
+The purpose of creating this MySQLBackupLocation Resource is to configure the namespace
 with the location of the blobstore and the credentials to access it.
 
-To create a TanzuMySQLBackupLocation resource:
+To create a MySQLBackupLocation resource:
 
 1. Find the `backuplocation.yaml` deployment template that you downloaded
    in the **Tanzu MySQL Deployment Templates** TGZ file from <%= vars.product_network %>.
@@ -74,36 +74,36 @@ To create a TanzuMySQLBackupLocation resource:
 
 2. Edit the file with the configuration for your external blobstore.
    For an explanation of the properties that you can set in this file,
-   see [Properties for the TanzuMySQLBackupLocation Resource](property-reference-backup-restore.html#backuplocation)
+   see [Properties for the MySQLBackupLocation Resource](property-reference-backup-restore.html#backuplocation)
    and [Properties for the Secret](property-reference-backup-restore.html#secret).
 
-3. Create the TanzuMySQLBackupLocation resource in the same namespace as the TanzuMySQL instances that
+3. Create the MySQLBackupLocation resource in the same namespace as the MySQL instances that
    you want to back up by running:
 
     ```
     kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
     ```
-    + Where is `DEVELOPMENT-NAMESPACE` is the namespace for the TanzuMySQL instance.
+    + Where is `DEVELOPMENT-NAMESPACE` is the namespace for the MySQL instance.
     + Where `FILENAME` is the name of the configuration file you created in Step 2 above.
 
     For example:
 
     <pre class="terminal">$ kubectl apply -f testbackuplocation.yaml -n my-namespace
-    tanzumysqlbackuplocation.mysql.tanzu.vmware.com/backuplocation-sample created
+    mysqlbackuplocation.sql.tanzu.vmware.com/backuplocation-sample created
     secret/backuplocation-sample-creds configured
     </pre>
 
-3. Verify that the TanzuMySQLBackupLocation has been created by running:
+3. Verify that the MySQLBackupLocation has been created by running:
 
     ```
-    kubectl get tanzumysqlbackuplocation backuplocation-sample \
+    kubectl get mysqlbackuplocation backuplocation-sample \
     -o jsonpath={.spec} -n DEVELOPMENT-NAMESPACE
     ```
 
     For example:
 
     <pre class="terminal">
-    $ kubectl get tanzumysqlbackuplocation backuplocation-sample -o jsonpath={.spec} -n my-namespace
+    $ kubectl get mysqlbackuplocation backuplocation-sample -o jsonpath={.spec} -n my-namespace
     {
       "storage": {
         "s3": {
@@ -119,9 +119,9 @@ To create a TanzuMySQLBackupLocation resource:
     }
     </pre>
 
-###<a id="create-backupschedule"></a> Create a TanzuMySQLBackupSchedule Resource
+###<a id="create-backupschedule"></a> Create a MySQLBackupSchedule Resource
 
-To set a schedule for automatic backups, create a TanzuMySQLBackupSchedule resource:
+To set a schedule for automatic backups, create a MySQLBackupSchedule resource:
 
 1. Find the `backupschedule.yaml` deployment template that you downloaded
    in the **Tanzu MySQL Deployment Templates** TGZ file from <%= vars.product_network %>.
@@ -134,14 +134,14 @@ To set a schedule for automatic backups, create a TanzuMySQLBackupSchedule resou
 
     <pre class="terminal">$ cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/backupschedule.yaml testbackupschedule.yaml</pre>
 
-2. Edit the file with the name of the TanzuMySQLBackupLocation resource
-   that you created in [Create a TanzuMySQLBackupLocation Resource](backup-restore.html#create-backuplocation)
-   and the name of the TanzuMySQL instance you want scheduled backups of.
+2. Edit the file with the name of the MySQLBackupLocation resource
+   that you created in [Create a MySQLBackupLocation Resource](backup-restore.html#create-backuplocation)
+   and the name of the MySQL instance you want scheduled backups of.
    For an explanation of the properties that you can set in this file,
-   see [Properties for the TanzuMySQLBackupSchedule Resource](property-reference-backup-restore.html#backupschedule).
+   see [Properties for the MySQLBackupSchedule Resource](property-reference-backup-restore.html#backupschedule).
 
-3. Create the TanzuMySQLBackupSchedule resource in the same namespace as the TanzuMySQLBackupLocation and TanzuMySQL instance that
-   you referenced in the TanzuMySQLBackupSchedule YAML file.
+3. Create the MySQLBackupSchedule resource in the same namespace as the MySQLBackupLocation and MySQL instance that
+   you referenced in the MySQLBackupSchedule YAML file.
 
     ```
     kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
@@ -150,18 +150,18 @@ To set a schedule for automatic backups, create a TanzuMySQLBackupSchedule resou
 
     For example:
     <pre class="terminal">$ kubectl apply -f testbackupschedule.yaml -n my-namespace
-    tanzumysqlbackupschedule.mysql.tanzu.vmware.com/backupschedule-sample created
+    mysqlbackupschedule.sql.tanzu.vmware.com/backupschedule-sample created
     </pre>
 
-4. Verify that the TanzuMySQLBackupSchedule has been created by running:
+4. Verify that the MySQLBackupSchedule has been created by running:
 
     ```
-    kubectl get tanzumysqlbackupschedule tanzumysqlbackupschedule-sample -o jsonpath={.spec} -n DEVELOPMENT-NAMESPACE
+    kubectl get mysqlbackupschedule mysqlbackupschedule-sample -o jsonpath={.spec} -n DEVELOPMENT-NAMESPACE
     ```
 
     For example:
     <pre class="terminal">
-    $ kubectl get tanzumysqlbackupschedule tanzumysqlbackupschedule-sample -o jsonpath={.spec} -n my-namespace
+    $ kubectl get mysqlbackupschedule mysqlbackupschedule-sample -o jsonpath={.spec} -n my-namespace
     {
       "backupTemplate": {
         "spec": {
@@ -177,14 +177,14 @@ To set a schedule for automatic backups, create a TanzuMySQLBackupSchedule resou
     }
     </pre>
 
-    If you correctly configured both a `TanzuMySQLBackupLocation` resource and
-    `TanzuMySQLBackupSchedule` resource for an existing TanzuMySQL instance,
+    If you correctly configured both a `MySQLBackupLocation` resource and
+    `MySQLBackupSchedule` resource for an existing MySQL instance,
     you see backups being generated and uploaded to the external blobstore.
 
 ###<a id="name-and-location"></a> Name and Location for Backup Artifacts
 
 
-TanzuMySQLBackup resources that are automatically generated as a result of a TanzuMySQLBackupSchedule are named
+MySQLBackup resources that are automatically generated as a result of a MySQLBackupSchedule are named
 `SCHEDULE-NAME-TIMESTAMP`.
 
 By default, <%= vars.product_short %> stores backup artifacts under the subfolder structure `yyyy > mm > dd`.
@@ -193,11 +193,11 @@ structure `CUSTOM-PATH > yyyy > mm > dd`.
 
 Backup artifacts stored in the external blobstore are named `DATETIME-RANDOM_STRING-backup.xb`.
 
-For example, if a TanzuMySQLBackupSchedule name is `tanzumysqlbackupschedule-sample`, the custom backup
+For example, if a MySQLBackupSchedule name is `mysqlbackupschedule-sample`, the custom backup
 path is `my-backups/`, and a backup was taken on Thursday, December 10, 2020 at 8:51:03 PM GMT
 (timestamp `1607633463`), then:
 
-* The TanzuMySQLBackup resource on the Kubernetes cluster is named `tanzumysqlbackupschedule-sample-1607633463`
+* The MySQLBackup resource on the Kubernetes cluster is named `mysqlbackupschedule-sample-1607633463`
 * The backup artifact in the external blobstore is named `20201210T205103-kzw54l-backup.xb`
 * The path to the artifact is `my-backups/2020/12/10/`.
 
@@ -205,10 +205,10 @@ path is `my-backups/`, and a backup was taken on Thursday, December 10, 2020 at 
 
 In addition to scheduled backups, you can take individual backups whenever you want.
 
-**Prerequisite:** A TanzuMySQLBackupLocation resource that represents the external blobstore
+**Prerequisite:** A MySQLBackupLocation resource that represents the external blobstore
 to which you upload the generated backup artifact.
-To configure the TanzuMySQLBackupLocation resource,
-see [Create a TanzuMySQLBackupLocation Resource](#create-backuplocation) above.
+To configure the MySQLBackupLocation resource,
+see [Create a MySQLBackupLocation Resource](#create-backuplocation) above.
 
 To take a backup:
 
@@ -224,10 +224,10 @@ To take a backup:
     <pre class="terminal">$ cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/backup.yaml testbackup.yaml</pre>
 
 3. Edit the file.
-   For an explanation of the properties that you can set for the TanzuMySQLBackup resource,
-   see [Properties for the TanzuMySQLBackup Resource](property-reference-backup-restore.html#on-demand-backup).
+   For an explanation of the properties that you can set for the MySQLBackup resource,
+   see [Properties for the MySQLBackup Resource](property-reference-backup-restore.html#on-demand-backup).
 
-4. Trigger the backup by creating the TanzuMySQLBackup resource in the same namespace as the instance by running:
+4. Trigger the backup by creating the MySQLBackup resource in the same namespace as the instance by running:
 
     ```
     kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
@@ -236,27 +236,27 @@ To take a backup:
 
     For example:
     <pre class="terminal">$ kubectl apply -f testbackup.yaml -n my-namespace
-    tanzumysqlbackup.mysql.tanzu.vmware.com/backup-sample created
+    mysqlbackup.sql.tanzu.vmware.com/backup-sample created
     </pre>
 
 5. Verify that a backup has been generated and track its progress by running:
 
     ```
-    kubectl get tanzumysqlbackup backup-sample -n DEVELOPMENT-NAMESPACE
+    kubectl get mysqlbackup backup-sample -n DEVELOPMENT-NAMESPACE
     ```
 
     For example:
-    <pre  class="terminal">$ kubectl get tanzumysqlbackup backup-sample -n my-namespace
+    <pre  class="terminal">$ kubectl get mysqlbackup backup-sample -n my-namespace
 NAME            STATUS      TIME SCHEDULED                TIME STARTED                  TIME COMPLETED                AGE
 backup-sample   Succeeded   2020-12-01T21:49:26.138676Z   2020-12-01T21:49:26.148835Z   2020-12-01T21:49:30.609250Z   16m
     </pre>
 
     For an explanation of what each column means,
-    see [List Existing TanzuMySQLBackup Resources](#list-resources) below.
+    see [List Existing MySQLBackup Resources](#list-resources) below.
 
-##<a id="list-resources"></a> List Existing TanzuMySQLBackup Resources
+##<a id="list-resources"></a> List Existing MySQLBackup Resources
 
-You might want to list existing TanzuMySQLBackup resources for various reasons, for example:
+You might want to list existing MySQLBackup resources for various reasons, for example:
 
 * To select a backup to restore.
   For steps to restore a backup, see [Restore](backup-restore.html#restore).
@@ -265,17 +265,17 @@ You might want to list existing TanzuMySQLBackup resources for various reasons, 
 * To find old backups that need to be cleaned up. For steps to delete backups,
   see [Delete Old Backup Artifacts](backup-restore.html#delete-backups).
 
-To see a list of existing TanzuMySQLBackup resources:
+To see a list of existing MySQLBackup resources:
 
-1. List existing TanzuMySQLBackup resources by running:
+1. List existing MySQLBackup resources by running:
 
     ```
-    kubectl get tanzumysqlbackup
+    kubectl get mysqlbackup
     ```
 
     For example:
     <pre  class="terminal">
-    $ kubectl get tanzumysqlbackup
+    $ kubectl get mysqlbackup
     NAME            STATUS   TIME SCHEDULED                TIME STARTED   TIME COMPLETED   AGE
     backup-sample   Failed   2020-12-09T18:28:23.339156Z                                   23h
     </pre>
@@ -294,8 +294,8 @@ To see a list of existing TanzuMySQLBackup resources:
                     <td> Represents the current status of the backup.
                         Allowed values are:
                         <ul>
-                           <li>Pending: The backup has been received but not scheduled on a TanzuMySQL Pod.</li>
-                           <li>Scheduled: The backup has been scheduled on a selected TanzuMySQL Pod but has not started.</li>
+                           <li>Pending: The backup has been received but not scheduled on a MySQL Pod.</li>
+                           <li>Scheduled: The backup has been scheduled on a selected MySQL Pod but has not started.</li>
                            <li>Running: The backup is being generated and streamed to the external blobstore.</li>
                            <li>Succeeded: The backup has completed successfully.</li>
                            <li>Failed: The backup has failed to complete.
@@ -306,7 +306,7 @@ To see a list of existing TanzuMySQLBackup resources:
               </tr>
              <tr>
                    <td><code>TIME SCHEDULED</code></td>
-                   <td> The time at which the backup was scheduled on a selected TanzuMySQL Pod.</td>
+                   <td> The time at which the backup was scheduled on a selected MySQL Pod.</td>
              </tr>
              <tr>
                    <td><code>TIME STARTED</code></td><td> The time that the backup process started.
@@ -326,22 +326,22 @@ To see a list of existing TanzuMySQLBackup resources:
 
 Tanzu MySQL for Kubernetes does not natively support retention policies for backup artifacts.
 You can configure retention policies on your external blobstore.
-If you do, you must also delete the associated TanzuMySQLBackup resources in the Kubernetes cluster,
+If you do, you must also delete the associated MySQLBackup resources in the Kubernetes cluster,
 because those are not automatically deleted by Tanzu MySQL for Kubernetes.
 
 To delete a backup:
 
 1. Delete the backup in the external blobstore.
 
-2. On your Kubernetes cluster, delete the TanzuMySQLBackup resource by running:
+2. On your Kubernetes cluster, delete the MySQLBackup resource by running:
 
     ```
-    kubectl delete tanzumysqlbackup BACKUP-NAME -n DEVELOPMENT-NAMESPACE
+    kubectl delete mysqlbackup BACKUP-NAME -n DEVELOPMENT-NAMESPACE
     ```
 
     For example:
 
-    <pre class="terminal">kubectl delete tanzumysqlbackup backup-sample -n my-namespace
+    <pre class="terminal">kubectl delete mysqlbackup backup-sample -n my-namespace
     </pre>
 
 
@@ -354,24 +354,24 @@ This section discusses two kinds of restoring:
 
 ###<a id="restore-from-backup"></a> Restore from a Backup
 
-TanzuMySQLRestores always restores to a new TanzuMySQL instance to avoid overwriting any data
-on an existing TanzuMySQL instance.
-The TanzuMySQL instance is created automatically when the restore is triggered.
+MySQLRestores always restores to a new MySQL instance to avoid overwriting any data
+on an existing MySQL instance.
+The MySQL instance is created automatically when the restore is triggered.
 
-<%= vars.product_short %> does not allow you to restore a backup to an existing TanzuMySQL instance.
+<%= vars.product_short %> does not allow you to restore a backup to an existing MySQL instance.
 Although you can perform this manually by copying the MySQL data from the backup artifact
-onto an existing TanzuMySQL instance,
+onto an existing MySQL instance,
 VMware strongly discourages you from doing this because
-you might overwrite existing data on the TanzuMySQL instance.
+you might overwrite existing data on the MySQL instance.
 
 #### Prerequisites
 
 Before you restore from a backup, you must have:
 
-*  An existing TanzuMySQLBackup in your current namespace. To select an existing TanzuMySQLBackup to
-   restore, see [List Existing TanzuMySQLBackup Resources](backup-restore.html#list-resources).
-*  A TanzuMySQLBackupLocation that represents the bucket where the existing backup artifact is stored.
-   See [Create a TanzuMySQLBackupLocation Resource](#create-backuplocation) above.
+*  An existing MySQLBackup in your current namespace. To select an existing MySQLBackup to
+   restore, see [List Existing MySQLBackup Resources](backup-restore.html#list-resources).
+*  A MySQLBackupLocation that represents the bucket where the existing backup artifact is stored.
+   See [Create a MySQLBackupLocation Resource](#create-backuplocation) above.
 
 #### Procedure
 
@@ -390,11 +390,11 @@ To restore from a backup:
 
 
 3. Edit the file.
-   For information about the properties that you can set for the TanzuMySQLRestore resource,
+   For information about the properties that you can set for the MySQLRestore resource,
    see [Property Reference for Backup and Restore](property-reference-backup-restore.html#restore).
 
-4. Trigger the restore by creating the TanzuMySQLRestore resource in the same namespace
-   as the TanzuMySQLBackup and TanzuMySQLBackupLocation by running:
+4. Trigger the restore by creating the MySQLRestore resource in the same namespace
+   as the MySQLBackup and MySQLBackupLocation by running:
 
     ```
     kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
@@ -404,20 +404,20 @@ To restore from a backup:
     For example:
     <pre  class="terminal">
     $ kubectl apply -f testrestore.yaml -n my-namespace
-    tanzumysqlrestore.mysql.tanzu.vmware.com/tanzumysqlrestore-sample created
+    mysqlrestore.sql.tanzu.vmware.com/mysqlrestore-sample created
     </pre>
 
 5. Verify that a restore has been triggered and track the progress of your restore by running:
 
     ```
-    kubectl get tanzumysqlrestore tanzumysqlrestore-sample -n DEVELOPMENT-NAMESPACE
+    kubectl get mysqlrestore mysqlrestore-sample -n DEVELOPMENT-NAMESPACE
     ```
 
     For example:
     <pre  class="terminal">
-    $ kubectl get tanzumysqlrestore tanzumysqlrestore-sample -n my-namespace
-    NAME                       STATUS      TIME STARTED                  TIME COMPLETED                AGE
-    tanzumysqlrestore-sample   Succeeded   2020-12-01T21:52:30.000000Z   2020-12-01T21:53:09.163336Z   13m
+    $ kubectl get mysqlrestore mysqlrestore-sample -n my-namespace
+    NAME                  STATUS      TIME STARTED                  TIME COMPLETED                AGE
+    mysqlrestore-sample   Succeeded   2020-12-01T21:52:30.000000Z   2020-12-01T21:53:09.163336Z   13m
    </pre>
 
 6. To understand the output, see the table below:
@@ -434,7 +434,7 @@ To restore from a backup:
                         Allowed values are:
                         <ul>
                            <li>Pending: The restore has been received but not yet scheduled
-                               on a TanzuMySQL Pod.</li>
+                               on a MySQL Pod.</li>
                            <li>Scheduled: The restore has been scheduled but has not started.</li>
                            <li>Running: The restore is in progress.</li>
                            <li>Succeeded: The restore has completed successfully.</li>
@@ -461,8 +461,8 @@ To restore from a backup:
 ###<a id="restore-to-different"></a> Restoring a Backup to a Different Namespace or Kubernetes Cluster
 
 If you want to restore a backup to a different namespace or a different Kubernetes cluster,
-create a `TanzuMySQLBackupLocation` in the target namespace or Kubernetes cluster.
-Then, <%= vars.product_short %> automatically creates `TanzuMySQLBackup` resources
+create a `MySQLBackupLocation` in the target namespace or Kubernetes cluster.
+Then, <%= vars.product_short %> automatically creates `MySQLBackup` resources
 for the backup artifacts in the external blobstore.
 
 To restore to a different namespace or Kubernetes cluster, you create a
@@ -470,17 +470,17 @@ BackupLocation in the target namespace:
 
 1. Target the destination cluster or namespace.
 
-1. Create a TanzuMySQLBackupLocation resource that contains the backup artifact to restore.
-   For how to do this, see [Create a TanzuMySQLBackupLocation Resource](#create-backuplocation).
+1. Create a MySQLBackupLocation resource that contains the backup artifact to restore.
+   For how to do this, see [Create a MySQLBackupLocation Resource](#create-backuplocation).
 
-1. Confirm that the TanzuMySQLBackup artifact to restore is included in the list by running:
+1. Confirm that the MySQLBackup artifact to restore is included in the list by running:
 
     ```
-    kubectl get tanzumysqlbackup
+    kubectl get mysqlbackup
     ```
    For example:
    <pre class='terminal'>
-   $ kubectl get tanzumysqlbackup
+   $ kubectl get mysqlbackup
      NAME            STATUS      TIME SCHEDULED                TIME STARTED                  TIME COMPLETED                AGE
      sample-backup   Succeeded   2020-12-01T21:49:26.138676Z   2020-12-01T21:49:26.148835Z   2020-12-01T21:49:30.609250Z   5d17h
    </pre>
@@ -494,17 +494,17 @@ reading the messages associated with the resource events.
 
 To troubleshoot problems with backup and restore:
 
-1. Detect issues by monitoring the `STATUS` column of any Tanzu MySQL custom resource.
+1. Detect issues by monitoring the `STATUS` column of any MySQL custom resource.
    If the status is `Failed` or is stuck in `Pending`, `Scheduled`, or `Running`,
     then one of the following might be the problem:
     + Misconfiguration
     + Problem with the external blobstore
-    + Issues with the TanzuMySQL Operator
+    + Issues with the Tanzu MySQL Operator
 
     In this example, the `kubectl get` command outputs a `Failed` status:
 
     <pre class="terminal">
-    $ kubectl get tanzumysqlbackup backup-sample
+    $ kubectl get mysqlbackup backup-sample
     NAME            STATUS   TIME SCHEDULED                TIME STARTED   TIME COMPLETED   AGE
     backup-sample   Failed   2020-12-09T18:28:23.339156Z                                   2m44s
    </pre>
@@ -512,8 +512,8 @@ To troubleshoot problems with backup and restore:
 2. Diagnose the issue by inspecting the Kubernetes events for the resource, for example:
     <pre class="terminal">
     $ kubectl get events --field-selector involvedObject.name=backup-sample
-    LAST SEEN   TYPE      REASON   OBJECT                           MESSAGE
-    2m43s       Warning   Failed   tanzumysqlbackup/backup-sample   Secret "backuplocation-sample-creds" not found
+    LAST SEEN   TYPE      REASON   OBJECT                      MESSAGE
+    2m43s       Warning   Failed   mysqlbackup/backup-sample   Secret "backuplocation-sample-creds" not found
     </pre>
 
 3. Read the message in the `MESSAGE` column to understand why the failure occurred.<br><br>

--- a/bind-app.html.md.erb
+++ b/bind-app.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Connecting an App to the TanzuMySQL Instance
+title: Connecting an App to the MySQL Instance
 owner: MySQL
 ---
 
@@ -7,20 +7,20 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-This topic explains how you, as a developer, connect an app to your TanzuMySQL instance.
+This topic explains how you, as a developer, connect an app to your MySQL instance.
 
-## <a id='AboutTile'></a>About Binding Apps to a TanzuMySQL Instance
+## <a id='AboutTile'></a>About Binding Apps to a MySQL Instance
 
-After you have created a TanzuMySQL instance,
+After you have created a MySQL instance,
 the next task is to bind it to your app so that your app can access the database.
 
 You do this by obtaining the password for the root database user and the IP address for the
-TanzuMySQL instance and then adding these connection parameters to the app environment variables.
+MySQL instance and then adding these connection parameters to the app environment variables.
 
 
 ## <a id='prereq'></a>Prerequisites
 
-Before you bind an app to a TanzuMySQL instance, you must have:
+Before you bind an app to a MySQL instance, you must have:
 
 * **The Kubernetes Command Line Interface (kubectl) installed:**
 For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
@@ -35,19 +35,19 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
        VMware recommends that developers have admin access to their target namespace.
     </p>
 
-* **A TanzuMySQL instance running in the same Kubernetes cluster as the app:**
+* **A MySQL instance running in the same Kubernetes cluster as the app:**
   This is required. The ServiceType is ClusterIP.
   However, instances can be in a different namespace from the app.<br>
-  For how to create an instance, see [Creating and Deleting a TanzuMySQL Instance](create-delete-mysql.html).<br>
+  For how to create an instance, see [Creating and Deleting a MySQL Instance](create-delete-mysql.html).<br>
   For information about the ClusterIP ServiceType, see the
   [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
 
-## <a id='retrieve-creds'></a>Retrieve Connection Parameters for the TanzuMySQL Instance
+## <a id='retrieve-creds'></a>Retrieve Connection Parameters for the MySQL Instance
 
 To connect the app to the database, you provide the app with:
 
 *  The root username and password for the database
-*  The IP address for the TanzuMySQL instance
+*  The IP address for the MySQL instance
 
 This procedure describes how to find these connection parameters.
 
@@ -59,12 +59,12 @@ To retrieve connection parameters:
     kubectl get secret INSTANCE-NAME-credentials -o jsonpath='{.data.rootPassword}' | base64 -D
     ```
 
-    Where `INSTANCE-NAME` is the name of the TanzuMySQL instance.
+    Where `INSTANCE-NAME` is the name of the MySQL instance.
 
     For example:
 
     <pre class="terminal">
-    $ kubectl get secret tanzumysql-sample-credentials \
+    $ kubectl get secret mysql-sample-credentials \
       -o jsonpath='{.data.rootPassword}' | base64 -D
     examplepassword
     </pre>
@@ -72,7 +72,7 @@ To retrieve connection parameters:
 2. Record the password string, for example, `examplepassword`.
    You need it to complete the [Connect your App to the MySQL Database](#connect-app) below.
 
-3. Obtain the IP address of the TanzuMySQL instance by running:
+3. Obtain the IP address of the MySQL instance by running:
 
     ```
     kubectl get service INSTANCE-NAME
@@ -80,11 +80,11 @@ To retrieve connection parameters:
 
     For example:
 
-    <pre class="terminal">$ kubectl get service tanzumysql-sample
+    <pre class="terminal">$ kubectl get service mysql-sample
 
-    → kubectl get service tanzumysql-sample
-NAME                TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)              AGE
-tanzumysql-sample   ClusterIP   10.110.144.49   <none>        3306/TCP,33060/TCP   5d22h
+    → kubectl get service mysql-sample
+NAME           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)              AGE
+mysql-sample   ClusterIP   10.110.144.49   <none>        3306/TCP,33060/TCP   5d22h
     </pre>
 
 2. Record the value of the `CLUSTER-IP`, for example, `10.110.144.49`.
@@ -92,7 +92,7 @@ tanzumysql-sample   ClusterIP   10.110.144.49   <none>        3306/TCP,33060/TCP
 
 ## <a id='connect-app'></a>Connect your App to the MySQL Database
 
-To connect your app to the MySQL database on the TanzuMySQL instance:
+To connect your app to the MySQL database on the MySQL instance:
 
 1. Manually configure the app environment variables with the connection parameters
    that you recorded above.

--- a/configure-tls.html.md.erb
+++ b/configure-tls.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Configuring TLS for a TanzuMySQL Instance
+title: Configuring TLS for a MySQL Instance
 owner: MySQL
 ---
 
@@ -7,7 +7,7 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-This topic describes how to configure TLS for a TanzuMySQL instance.
+This topic describes how to configure TLS for a MySQL instance.
 
 ## <a id='overview'></a>Overview
 
@@ -16,9 +16,9 @@ client connections cannot fall back to use an unencrypted connection. By default
 the MySQL server uses a self-signed certificate. Clients can connect to the MySQL server,
 but they cannot verify the connection.
 
-To verify the connection to the MySQL server, the TanzuMySQL instance can be configured with a TLS certificate and private key.
+To verify the connection to the MySQL server, the MySQL instance can be configured with a TLS certificate and private key.
 
-To configure a TanzuMySQL instance for TLS, you must first create
+To configure a MySQL instance for TLS, you must first create
 a TLS Secret in the namespace.
 There are several ways to create the Secret.
 This topic describes two methods:
@@ -30,7 +30,7 @@ This topic describes two methods:
 
 After creating the secret, you add the name of the secret to your copy of the `mysql.yaml` file,
 and configure the instance with the updated file, as described in
-[Configure TanzuMySQL for TLS](#use-tls) below.
+[Configure MySQL for TLS](#use-tls) below.
 
 For general information about TLS secrets,
 see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).
@@ -38,9 +38,9 @@ see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configura
 
 ## <a id='prereq'></a>Prerequisites
 
-Before you configure TLS for a TanzuMySQL Instance, you must have:
+Before you configure TLS for a MySQL Instance, you must have:
 
-* **Access and permissions to the TanzuMySQL instance.**
+* **Access and permissions to the MySQL instance.**
 
 * **The Kubernetes Command Line Interface (kubectl) installed:**
   For more information,
@@ -58,8 +58,8 @@ see [Create TLS Secret with cert-manager](#using-cert-manager) below.
    <br><br>
    When creating the certificate, supply the server hostname for the
    subject alternative names (SANs).
-   - If the TanzuMySQL ServiceType is ClusterIP, the hostnames are localhost and 127.0.0.1.
-   - If the TanzuMySQL ServiceType is LoadBalancer, hostname is the external DNS name of the load balancer.
+   - If the MySQL ServiceType is ClusterIP, the hostnames are localhost and 127.0.0.1.
+   - If the MySQL ServiceType is LoadBalancer, hostname is the external DNS name of the load balancer.
 
 1. Create the TLS Secret by running:
 
@@ -69,7 +69,7 @@ see [Create TLS Secret with cert-manager](#using-cert-manager) below.
       --key=PATH-TO-PRIVATE-KEY
     ```
     Where:
-    + `DEVELOPMENT-NAMESPACE` is the namespace for the TanzuMySQL instance.
+    + `DEVELOPMENT-NAMESPACE` is the namespace for the MySQL instance.
     + `SECRET-NAME` is the name you choose for the TLS Secret.
     + `PATH-TO-CERTIFICATE` is the file path to the certificate created in the step above.
     + `PATH-TO-PRIVATE-KEY` is the file path to the private key created in the step above.
@@ -107,14 +107,14 @@ For information about installing Helm, see the
    For information about the Issuer types,
    see the [cert-manager documentation](https://cert-manager.io/docs/configuration/).
 
-3. Create a Certificate resource in the same namespace as the TanzuMySQL instance.
+3. Create a Certificate resource in the same namespace as the MySQL instance.
    Then, cert-manager creates the TLS Secret.
    <br><br>
    When creating the Certificate resource, supply the server hostname for the
    subject alternative names (SANs) using the `spec.dnsNames` and `spec.ipAddresses`
    configuration in the resource.
-   - If the TanzuMySQL ServiceType is ClusterIP, the DNS is localhost and IP address is 127.0.0.1.
-   - If the TanzuMySQL ServiceType is LoadBalancer, the DNS is the external DNS name of the load balancer.
+   - If the MySQL ServiceType is ClusterIP, the DNS is localhost and IP address is 127.0.0.1.
+   - If the MySQL ServiceType is LoadBalancer, the DNS is the external DNS name of the load balancer.
 
     For how to specify the configuration of the Certificate resource,
    see the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/).
@@ -127,7 +127,7 @@ For information about installing Helm, see the
     kubectl -n DEVELOPMENT-NAMESPACE get secrets TLS-SECRET-NAME
     ```
     Where:
-    +  `DEVELOPMENT-NAMESPACE` is the namespace for the TanzuMySQL instance.
+    +  `DEVELOPMENT-NAMESPACE` is the namespace for the MySQL instance.
     +  `TLS-SECRET-NAME` is the value of the `spec.secretName` from the Certificate,
         recorded in step 4 above.
 
@@ -140,37 +140,37 @@ For information about installing Helm, see the
     see the [cert-manager documentation](https://cert-manager.io/docs/faq/troubleshooting/).
 
 
-## <a id='use-tls'></a>Configure TanzuMySQL for TLS
+## <a id='use-tls'></a>Configure MySQL for TLS
 
-To configure TLS for the TanzuMySQL instance:
+To configure TLS for the MySQL instance:
 
-1. In your copy of the `mysql.yaml` for the TanzuMySQL instance, specify `spec.tls.secret.name` as the name
+1. In your copy of the `mysql.yaml` for the MySQL instance, specify `spec.tls.secret.name` as the name
 of the TLS Secret created in the namespace.
 
-2. Create or update the TanzuMySQL instance by running:
+2. Create or update the MySQL instance by running:
 
     ```
     kubectl apply -f FILENAME -n DEVELOPMENT-NAMESPACE
     ```
     Where:
-    +  `FILENAME` is the name of the configuration file for your TanzuMySQL resource.
-    +  `DEVELOPMENT-NAMESPACE` is the namespace for the TanzuMySQL instance.
+    +  `FILENAME` is the name of the configuration file for your MySQL resource.
+    +  `DEVELOPMENT-NAMESPACE` is the namespace for the MySQL instance.
 
 
 
-## <a id='use-tls'></a>Connect to TanzuMySQL over TLS
+## <a id='use-tls'></a>Connect to MySQL over TLS
 
 To allow client connections to verify the MySQL server certificate,
 you provide the CA certificate to the app.
 
-To connect an app or other client to the TanzuMySQL instance over TLS:
+To connect an app or other client to the MySQL instance over TLS:
 
 
 1. Find the certificate authority that signed the TLS certificate.
 
-1. Try connecting to your TanzuMySQL instance using an app or through the proxy port:
-    + To connect an app to a TanzuMySQL instance,
-    see [Connecting an App to the TanzuMySQL Instance](.//bind-app.html).<br><br>
+1. Try connecting to your MySQL instance using an app or through the proxy port:
+    + To connect an app to a MySQL instance,
+    see [Connecting an App to the MySQL Instance](.//bind-app.html).<br><br>
     + To connect to the MySQL server through the proxy port:
         1. Follow steps 1 and 2 of
         [Connect to the MySQL Server with the Kubernetes API Server](accessing.html#port-forward).

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Creating and Deleting a TanzuMySQL Instance
+title: Creating and Deleting a MySQL Instance
 owner: MySQL
 ---
 
@@ -7,11 +7,11 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-This topic describes how you, as a developer, deploy and delete TanzuMySQL instances.
+This topic describes how you, as a developer, deploy and delete MySQL instances.
 
 ## <a id='prerequisites'></a> Prerequisites
 
-Before you can create or delete TanzuMySQL instances, you must have:
+Before you can create or delete MySQL instances, you must have:
 
 * **The Kubernetes Command Line Interface (kubectl) installed:**
 For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
@@ -26,11 +26,11 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
     If you do not have access to the registry credentials, contact your Kubernetes admin
     to have these set up for you in your namespace.
 
-## <a id='create-instance'></a>Create a TanzuMySQL Instance
+## <a id='create-instance'></a>Create a MySQL Instance
 
-To create a TanzuMySQL instance:
+To create a MySQL instance:
 
-1. Target the namespace where you want to create the TanzuMySQL instance:
+1. Target the namespace where you want to create the MySQL instance:
 
     ```
     kubectl config set-context --current --namespace=DEVELOPMENT-NAMESPACE
@@ -77,10 +77,10 @@ To create a TanzuMySQL instance:
 
 
 5. Edit the file.
-   For information about the properties that you can set for the TanzuMySQL resource,
-   see [Property Reference for the TanzuMySQL Resource](property-reference-tanzumysql.html).
+   For information about the properties that you can set for the MySQL resource,
+   see [Property Reference for the MySQL Resource](property-reference-mysql.html).
 
-6. Deploy a TanzuMySQL instance to Kubernetes by running:
+6. Deploy a MySQL instance to Kubernetes by running:
 
     ```
     kubectl -n DEVELOPMENT-NAMESPACE apply -f FILENAME
@@ -90,26 +90,26 @@ To create a TanzuMySQL instance:
     For example:
 
     <pre class="terminal">$ kubectl -n my-namespace apply -f testdb.yaml
-    tanzumysql.mysql.tanzu.vmware.com/tanzumysql-sample created
+    mysql.sql.tanzu.vmware.com/mysql-sample created
     </pre>
 
 
 7. Verify that the instance was created successfully by running:
 
     ```
-    kubectl -n DEVELOPMENT-NAMESPACE get tanzumysql INSTANCE-NAME
+    kubectl -n DEVELOPMENT-NAMESPACE get mysql INSTANCE-NAME
     ```
     Where `INSTANCE-NAME` is the value that you configured for `metadata.name` in your file
     <br><br>
     For example:
 
-    <pre class="terminal">$ kubectl -n my-namespace get tanzumysql tanzumysql-sample
-NAME                READY   STATUS    AGE
-tanzumysql-sample   true    Running   2m17s
+    <pre class="terminal">$ kubectl -n my-namespace get mysql mysql-sample
+NAME           READY   STATUS    AGE
+mysql-sample   true    Running   2m17s
     </pre>
 
 
-## <a id='delete-instance'></a>Delete a TanzuMySQL Instance
+## <a id='delete-instance'></a>Delete a MySQL Instance
 
 This section provides some conceptual information about persistent volume claims (PVCs)
 and deleting an instance.
@@ -117,21 +117,21 @@ It also provides the procedure for how to delete an instance.
 
 ###<a id="about-pvcs"></a> About PVCs
 
-When you create a TanzuMySQL instance, the Tanzu MySQL Operator also creates a persistent
+When you create a MySQL instance, the Tanzu MySQL Operator also creates a persistent
 volume claim (PVC).
 This PVC is attached to the instance and contains the data for the MySQL database.
 
-The PVC name contains the instance name and the TanzuMySQL Pod number.
+The PVC name contains the instance name and the MySQL Pod number.
 Currently only one Pod is allowed per instance, so the PVC name is of the form
 <code>mysql-data-INSTANCE-NAME-N</code>.
-For example, <code>mysql-data-tanzumysql-sample-0</code>
+For example, <code>mysql-data-mysql-sample-0</code>
 
 <p class="note">
    <strong>Note:</strong>
 Currently only one Pod is allowed per instance, so <code>N</code> is always <code>0</code>.
 </p>
 
-###<a id="about-deleting"></a> About Deleting a TanzuMySQL Instance
+###<a id="about-deleting"></a> About Deleting a MySQL Instance
 
 There are two steps to deleting an instance.
 The first step is to delete the instance itself, and the second step is to delete the PVC.
@@ -147,18 +147,18 @@ the old PVC automatically reattaches to the new instance and you have access to 
    <strong>Note:</strong> If you delete the Pod or the StatefulSet associated
    with the <%= vars.product_short %> resource,
    a <%= vars.product_short %> controller re-creates it for you.
-   To permanently delete the instance, you need to delete the <code>tanzumysql</code> resource,
+   To permanently delete the instance, you need to delete the MySQL resource,
    as described in step 1 below.
 </p>
 
 ###<a id="procedure"></a> Procedure
 
-To delete a TanzuMySQL instance:
+To delete a MySQL instance:
 
-1. Delete the TanzuMySQL instance by running:
+1. Delete the MySQL instance by running:
 
     ```
-    kubectl -n DEVELOPMENT-NAMESPACE delete tanzumysql INSTANCE-NAME
+    kubectl -n DEVELOPMENT-NAMESPACE delete mysql INSTANCE-NAME
     ```
 
     Where:
@@ -168,8 +168,8 @@ To delete a TanzuMySQL instance:
     For example:
 
     <pre class="terminal">
-    $ kubectl -n my-namespace delete tanzumysql tanzumysql-sample
-    my-namespace "tanzumysql-sample" deleted
+    $ kubectl -n my-namespace delete mysql mysql-sample
+    my-namespace "mysql-sample" deleted
     </pre>
 
 2. (Optional) Delete the Persistent Volume Claim (PVC).
@@ -190,23 +190,23 @@ To delete a TanzuMySQL instance:
         <pre class="terminal">
        $ kubectl get pvc
 NAME                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-mysql-data-tanzumysql-sample-0    Bound    pvc-3262e841-c4aa-4aa4-b53a-68cd3078f806   1Gi        RWO            standard       7d1h
+mysql-data-mysql-sample-0         Bound    pvc-3262e841-c4aa-4aa4-b53a-68cd3078f806   1Gi        RWO            standard       7d1h
 mysql-data-another-sample-0       Bound    pvc-87c8a3a9-263b-46e6-8acb-ed474434fd24   1Gi        RWO            standard       6d21h</pre>
 
     2. Identify the names of the PVCs that correspond to the name of the instance you deleted above.
 
-    3. Delete the PVC associated with each TanzuMySQL Pod by running, for each Pod:
+    3. Delete the PVC associated with each MySQL Pod by running, for each Pod:
 
         ```
         kubectl delete pvc mysql-data-INSTANCE-NAME-N
         ```
 
         Where:
-        + `INSTANCE-NAME` is the name of the TanzuMySQL instance that you deleted above.
-        + `N` is the index of each Pod in the TanzuMySQL instance.
+        + `INSTANCE-NAME` is the name of the MySQL instance that you deleted above.
+        + `N` is the index of each Pod in the MySQL instance.
 
         For example:
 
         <pre class="terminal">
-       $ kubectl delete pvc mysql-data-tanzumysql-sample-0
-persistentvolumeclaim "mysql-data-tanzumysql-sample-0" deleted</pre>
+       $ kubectl delete pvc mysql-data-mysql-sample-0
+persistentvolumeclaim "mysql-data-mysql-sample-0" deleted</pre>

--- a/property-reference-backup-restore.html.md.erb
+++ b/property-reference-backup-restore.html.md.erb
@@ -4,11 +4,11 @@ owner: MySQL
 ---
 
 **In this topic**<br>
-[Properties for the TanzuMySQLBackupLocation Resource](#backuplocation)<br>
+[Properties for the MySQLBackupLocation Resource](#backuplocation)<br>
 [Properties for the Secret](#secret)<br>
-[Properties for the TanzuMySQLBackupSchedule Resource](#backupschedule)<br>
-[Properties for the TanzuMySQLBackup Resource](#on-demand-backup)<br>
-[Properties for the TanzuMySQLRestore Resource](#restore)
+[Properties for the MySQLBackupSchedule Resource](#backupschedule)<br>
+[Properties for the MySQLBackup Resource](#on-demand-backup)<br>
+[Properties for the MySQLRestore Resource](#restore)
 
 <%= partial '../../mysql-k8s/partials/mysql-k8s/product-beta-warning' %>
 
@@ -19,9 +19,9 @@ backup and restore.
 For information about backup and restore,
 see [Backing Up and Restoring in Tanzu MySQL for Kubernetes](backup-restore.html).
 
-##<a name="backuplocation"></a> Properties for the TanzuMySQLBackupLocation Resource
+##<a name="backuplocation"></a> Properties for the MySQLBackupLocation Resource
 
-The table below explains the properties that can be set for the TanzuMySQLBackupLocation resource.
+The table below explains the properties that can be set for the MySQLBackupLocation resource.
 
 <table style="width:1000px" class="nice">
 <col width="10%">
@@ -42,7 +42,7 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
   <td>metadata.name</td>
   <td>String</td>
   <td><em>n/a</em></td>
-  <td>The name of the TanzuMySQLBackupLocation. Must be unique within a namespace.</td>
+  <td>The name of the MySQLBackupLocation. Must be unique within a namespace.</td>
   <td><code>backuplocation-sample</code></td>
   <td>Yes</td>
 </tr>
@@ -115,7 +115,7 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
 
 ##<a name="secret"></a> Properties for the Secret
 
-The table below explains the properties that can be set in the `secret` for the TanzuMySQLBackupLocation resource.
+The table below explains the properties that can be set in the `secret` for the MySQLBackupLocation resource.
 
 <table style="width:1000px" class="nice">
 <col width="10%">
@@ -160,9 +160,9 @@ The table below explains the properties that can be set in the `secret` for the 
 </table>
 
 
-##<a name="backupschedule"></a> Properties for the TanzuMySQLBackupSchedule Resource
+##<a name="backupschedule"></a> Properties for the MySQLBackupSchedule Resource
 
-The table below explains the properties that can be set for the TanzuMySQLBackupSchedule resource.
+The table below explains the properties that can be set for the MySQLBackupSchedule resource.
 <table style="width:1000px" class="nice">
 <col width="10%">
 <col width="15%">
@@ -182,7 +182,7 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
    <td>metadata.name</td>
    <td>String</td>
    <td><em>n/a</em></td>
-   <td>The name of the TanzuMySQLBackupSchedule. Must be unique within a namespace.</td>
+   <td>The name of the MySQLBackupSchedule. Must be unique within a namespace.</td>
    <td><code>backupschedule-sample</code></td>
    <td>Yes</td>
 </tr>
@@ -190,7 +190,7 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
 <td>spec.backupTemplate.spec.location.name</td>
    <td>String</td>
    <td><em>n/a</em></td>
-   <td>The name of the TanzuMySQLBackupLocation that represents the blobstore where backups will be uploaded. Must be in the same namespace as the TanzuMySQLBackupSchedule.</td>
+   <td>The name of the MySQLBackupLocation that represents the blobstore where backups will be uploaded. Must be in the same namespace as the MySQLBackupSchedule.</td>
    <td><code>backuplocation-sample</td>
    <td>Yes</td>
 <tr>
@@ -198,9 +198,9 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
    <td>spec.backupTemplate.spec.cluster.name</td>
    <td>String</td>
    <td><em>n/a</em></td>
-   <td>The name of the TanzuMySQL instance on which you want scheduled backups for.
-       Must be in the same namespace as the TanzuMySQLBackupSchedule.</td>
-   <td><code>tanzumysql-sample</td>
+   <td>The name of the MySQL instance on which you want scheduled backups for.
+       Must be in the same namespace as the MySQLBackupSchedule.</td>
+   <td><code>mysql-sample</td>
    <td>Yes</td>
 <tr>
 </tr>
@@ -214,9 +214,9 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
 </table>
 
 
-##<a name="on-demand-backup"></a> Properties for the TanzuMySQLBackup Resource
+##<a name="on-demand-backup"></a> Properties for the MySQLBackup Resource
 
-The table below explains the properties that can be set for the TanzuMySQLBackup resource.
+The table below explains the properties that can be set for the MySQLBackup resource.
 
 [//]: # ( MISSING EXAMPLES)
 
@@ -239,7 +239,7 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
   <td>metadata.name</td>
   <td>String</td>
   <td><em>n/a</em></td>
-  <td>The name of the TanzuMySQLBackup.
+  <td>The name of the MySQLBackup.
       Must be unique within a namespace.</td>
   <td><code>backup-sample</code></td>
   <td>Yes</td>
@@ -248,8 +248,8 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
   <td>spec.location.name</td>
   <td>String</td>
   <td><em>n/a</em></td>
-  <td>The name of the TanzuMySQLBackupLocation that represents the blobstore where the backup will be uploaded.
-      Must be in the same namespace as the TanzuMySQL instance.</td>
+  <td>The name of the MySQLBackupLocation that represents the blobstore where the backup will be uploaded.
+      Must be in the same namespace as the MySQL instance.</td>
   <td><code>backuplocation-sample</code></td>
   <td>Yes</td>
 </tr>
@@ -257,7 +257,7 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
   <td>spec.cluster.name</td>
   <td>String</td>
   <td><em>n/a</em></td>
-  <td>The name of the TanzuMySQL instance on which you want to perform the on-demand backup.</td>
+  <td>The name of the MySQL instance on which you want to perform the on-demand backup.</td>
   <td><code>my-instance</code></td>
   <td>Yes</td>
 </tr>
@@ -265,9 +265,9 @@ The table below explains the properties that can be set for the TanzuMySQLBackup
 
 
 
-##<a name="restore"></a> Properties for the TanzuMySQLRestore Resource
+##<a name="restore"></a> Properties for the MySQLRestore Resource
 
-The table below explains the properties that can be set for the TanzuMySQLRestore resource.
+The table below explains the properties that can be set for the MySQLRestore resource.
 
 
 <table style="width:1000px" class="nice">
@@ -289,39 +289,39 @@ The table below explains the properties that can be set for the TanzuMySQLRestor
   <td>metadata.name</td>
   <td>String</td>
   <td><em>n/a</em></td>
-  <td>The name of the TanzuMySQLRestore. Must be unique within a namespace.</td>
-  <td><code>tanzumysqlrestore-sample</code></td>
+  <td>The name of the MySQLRestore. Must be unique within a namespace.</td>
+  <td><code>mysqlrestore-sample</code></td>
   <td>Yes</td>
 </tr>
 <tr>
-   <td>spec.tanzuMySQLBackup.name</td>
+   <td>spec.mysqlBackup.name</td>
    <td>String</td>
    <td><em>n/a</em></td>
-   <td>The name of the TanzuMySQLBackup that represents the backup artifact to restore.
-       Must be in the same namespace as the TanzuMySQLRestore.</td>
+   <td>The name of the MySQLBackup that represents the backup artifact to restore.
+       Must be in the same namespace as the MySQLRestore.</td>
    <td><code>backup-sample</code></td>
    <td>Yes</td>
 </tr>
 <tr>
-   <td>spec.tanzuMysqlTemplate</td>
-   <td>TanzuMySQL</td>
+   <td>spec.mysqlTemplate</td>
+   <td>MySQL</td>
    <td><em>n/a</em></td>
-   <td>The configuration for the TanzuMySQL instance that the backup artifact will be restored to.
-       This TanzuMySQL instance is created automatically as part of the restore,
+   <td>The configuration for the MySQL instance that the backup artifact will be restored to.
+       This MySQL instance is created automatically as part of the restore,
        so the name must not already exist in the namespace.<br>
        For descriptions of each value in the configuration template,
-      see <a href="create-delete-mysql.html#create-instance">Create a TanzuMySQL Instance</a>.</td>
+      see <a href="create-delete-mysql.html#create-instance">Create a MySQL Instance</a>.</td>
    <td>See example below.*</td>
    <td>Yes</td>
 </tr>
 </table>
 
 <br>
-* The type TanzuMySQL is a nested YAML object.
+* The type MySQL is a nested YAML object.
 For example:
 <pre>
 metadata:
-  name: tanzumysql-sample
+  name: mysql-sample
 spec:
   storageSize: 1Gi
   imagePullSecret: tanzu-mysql-image-registry

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Property Reference for the TanzuMySQL Resource
+title: Property Reference for the MySQL Resource
 owner: MySQL
 ---
 
@@ -7,12 +7,12 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-This topic is a property reference table for the TanzuMySQL resource.
-Refer to this table when you are creating the YAML file for a TanzuMySQL instance.
-For more information, see [Create a TanzuMysql Instance](create-delete-mysql.html#create-instance) in
-_Creating and Deleting a TanzuMySQL Instance_.
+This topic is a property reference table for the MySQL resource.
+Refer to this table when you are creating the YAML file for a MySQL instance.
+For more information, see [Create a Mysql Instance](create-delete-mysql.html#create-instance) in
+_Creating and Deleting a MySQL Instance_.
 
-The table below explains the properties that you can set in your TanzuMySQL resource.
+The table below explains the properties that you can set in your MySQL resource.
 
 <table style="width:1000px" class="nice">
 <col width="15%">
@@ -31,7 +31,7 @@ The table below explains the properties that you can set in your TanzuMySQL reso
   <td><code>metadata.name</code></td>
   <td>String</td>
   <td><em>n/a</em></td>
-  <td>The name of your TanzuMySQL instance:<br><br>
+  <td>The name of your MySQL instance:<br><br>
       <ul>
          <li>Must be unique within a namespace</li>
          <li>Cannot be updated</li>
@@ -61,7 +61,7 @@ The table below explains the properties that you can set in your TanzuMySQL reso
   <td>String</td>
   <td><em>n/a</em></td>
   <td>Refers to an existing Kubernetes docker-registry secret that can access the
-    registry that contains the TanzuMySQL image.</td>
+    registry that contains the MySQL image.</td>
   <td><code>tanzu-mysql-image-registry</code></td>
   <td>Yes</td>
 </tr>

--- a/rotating-credentials.html.md.erb
+++ b/rotating-credentials.html.md.erb
@@ -26,7 +26,7 @@ This topic provides multiple methods for rotating passwords for a
 Kubernetes automatically re-creates the secret with newly generated passwords.
 
 * [Option 2: Patch the Kubernetes Secret with a Custom Password](#patch-secret):
-This procedure enables you to configure Tanzu MySQL with your own custom passwords.
+This procedure enables you to configure MySQL with your own custom passwords.
 It also enables you to rotate the root password and the backup user password individually.
 
 ## <a id='prereq'></a>Prerequisites
@@ -57,8 +57,8 @@ This procedure rotates both the MySQL root password and the backup user password
 
     For example:
 
-    <pre class="terminal">$ kubectl delete secret tanzumysql-sample-credentials
-    <br>secret "tanzumysql-sample-credentials" deleted
+    <pre class="terminal">$ kubectl delete secret mysql-sample-credentials
+    <br>secret "mysql-sample-credentials" deleted
     </pre>
 
 1. Wait until Kubernetes has automatically re-created the secret.
@@ -72,7 +72,7 @@ This procedure rotates both the MySQL root password and the backup user password
     <pre class="terminal">$ kubectl get secret --watch
     <br>NAME                                  TYPE                                  DATA   AGE
     default-token-wb7gl                   kubernetes.io/service-account-token   3      10d
-    <span style="color: #77bf00;">tanzumysql-sample-credentials         Opaque                                4      48s</span>
+    <span style="color: #77bf00;">mysql-sample-credentials         Opaque                                4      48s</span>
     tanzu-mysql-backup-cron-token-c7bnt   kubernetes.io/service-account-token   3      10d
     tanzu-mysql-image-registry            kubernetes.io/dockerconfigjson        1      2m3s
     tanzu-mysql-token-24cdv               kubernetes.io/service-account-token   3      10d
@@ -86,22 +86,22 @@ This procedure rotates both the MySQL root password and the backup user password
 
     For example:
 
-    <pre class="terminal">$ kubectl rollout restart statefulset tanzumysql-sample
-    <br>statefulset.apps/tanzumysql-sample restarted
+    <pre class="terminal">$ kubectl rollout restart statefulset mysql-sample
+    <br>statefulset.apps/mysql-sample restarted
     </pre>
 
 1. Verify that your <%= vars.product_short %> instance has finished updating by running:
 
     ```
-    kubectl get tanzumysql INSTANCE-NAME
+    kubectl get mysql INSTANCE-NAME
     ```
     A <%= vars.product_short %> instance has finished updating when the value of the `STATUS`
     column is `Running`.
     For example:
 
-    <pre class="terminal">$ kubectl get tanzumysql tanzumysql-sample
-    <br>NAME                READY   STATUS    AGE
-    tanzumysql-sample   true    Running   10d
+    <pre class="terminal">$ kubectl get mysql mysql-sample
+    <br>NAME           READY   STATUS    AGE
+    mysql-sample   true    Running   10d
     </pre>
 
 1. To verify that the passwords were rotated successfully, try connecting to your
@@ -111,7 +111,7 @@ This procedure rotates both the MySQL root password and the backup user password
 ## <a id='patch-secret'></a>Option 2: Patch the Kubernetes Secret with a Custom Password
 
 This option patches the existing Kubernetes secret with a new password.
-This procedure allows you to configure Tanzu MySQL with your own custom passwords.
+This procedure allows you to configure MySQL with your own custom passwords.
 You can use this procedure to rotate either the MySQL root password or the backup
 user password.
 
@@ -129,8 +129,8 @@ user password.
 
     For example:
 
-    <pre class="terminal">$ kubectl patch secret tanzumysql-sample-credentials -p='{"stringData":{"rootPassword":"examplepassword"}}'
-    <br>secret/tanzumysql-sample-credentials patched
+    <pre class="terminal">$ kubectl patch secret mysql-sample-credentials -p='{"stringData":{"rootPassword":"examplepassword"}}'
+    <br>secret/mysql-sample-credentials patched
     </pre>
 
 1. To update the database with the new password, restart your <%= vars.product_short %> instance
@@ -141,22 +141,22 @@ user password.
     ```
     For example:
 
-    <pre class="terminal">$ kubectl rollout restart statefulset tanzumysql-sample
-    <br>statefulset.apps/tanzumysql-sample restarted
+    <pre class="terminal">$ kubectl rollout restart statefulset mysql-sample
+    <br>statefulset.apps/mysql-sample restarted
     </pre>
 
 1. Verify that your <%= vars.product_short %> instance has finished updating by running:
 
     ```
-    kubectl get tanzumysql INSTANCE-NAME
+    kubectl get mysql INSTANCE-NAME
     ```
     A <%= vars.product_short %> instance has finished updating when the value of the `STATUS`
     column is `Running`.
     For example:
 
-    <pre class="terminal">$ kubectl get tanzumysql tanzumysql-sample
-    <br>NAME                READY   STATUS    AGE
-    tanzumysql-sample   true    Running   10d
+    <pre class="terminal">$ kubectl get mysql mysql-sample
+    <br>NAME           READY   STATUS    AGE
+    mysql-sample   true    Running   10d
     </pre>
 
 1. To verify that the password was rotated successfully, try connecting to your

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Updating a TanzuMySQL Instance
+title: Updating a MySQL Instance
 owner: MySQL
 ---
 
@@ -39,23 +39,23 @@ To scale `storageSize`:
     <pre class="terminal">$ kubectl config set-context --current --namespace=my-namespace
     </pre>
 
-1. Look up the storage class associated with the TanzuMySQL Pod’s Persistent Volume Claim (PVC):
+1. Look up the storage class associated with the MySQL Pod’s Persistent Volume Claim (PVC):
 
     ```
     kubectl get pvc mysql-data-INSTANCE-NAME-N -o jsonpath={.spec.storageClassName}
     ```
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
-    + `N` is the index of the Pod in the TanzuMySQL instance.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your MySQL resource.
+    + `N` is the index of the Pod in the MySQL instance.
 
     For example:
 
-    <pre class="terminal">$ kubectl get pvc mysql-data-tanzumysql-sample-0 -o jsonpath={.spec.storageClassName}
+    <pre class="terminal">$ kubectl get pvc mysql-data-mysql-sample-0 -o jsonpath={.spec.storageClassName}
       standard
     </pre>
     <p class="note">
        <strong>Note:</strong>
-    Currently only one TanzuMySQL Pod is allowed per instance, so <code>N</code> is always <code>0</code>.
+    Currently only one MySQL Pod is allowed per instance, so <code>N</code> is always <code>0</code>.
     </p>
 
 1. Check if the storage class allows volume expansion. Look for the `ALLOWVOLUMEEXPANSION` column by running:
@@ -63,7 +63,7 @@ To scale `storageSize`:
     ```
     kubectl get storageclass CLASS-RETURNED
     ```
-    Where `CLASS-RETURNED` is the `storageclass` associated with the TanzuMySQL Pod's PVC from the previous step.
+    Where `CLASS-RETURNED` is the `storageclass` associated with the MySQL Pod's PVC from the previous step.
 
     For example:
 
@@ -88,12 +88,12 @@ To scale `storageSize`:
     '{"spec": {"resources": {"requests": {"storage": "NEW-REQUESTED-SIZE"}}}}'
     ```
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
-    + `N` is the index of the Pod in the TanzuMySQL instance.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your MySQL resource.
+    + `N` is the index of the Pod in the MySQL instance.
     + `NEW-REQUESTED-SIZE` is the increased volume size.
 
     For example:
-    <pre class="terminal">$ kubectl patch pvc mysql-data-tanzumysql-sample-0 -p \
+    <pre class="terminal">$ kubectl patch pvc mysql-data-mysql-sample-0 -p \
     '{"spec": {"resources": {"requests": {"storage": "50Gi"}}}}'</pre>
 
 1. Do one of the following:
@@ -101,27 +101,27 @@ To scale `storageSize`:
       Wait for the PVC to automatically resize. For more information, see the
       [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim).<br><br>
     * **Otherwise:** Wait for the PVC to have the `FileSystemResizePending` condition.
-    Delete the TanzuMySQL Pod to unmount the PVC and allow it to resize.
+    Delete the MySQL Pod to unmount the PVC and allow it to resize.
     <pre><code>kubectl wait --for=condition=FileSystemResizePending pvc/mysql-data-INSTANCE-NAME-N</code></pre>
     <pre><code>kubectl rollout restart statefulset MYSQL-INSTANCE-NAME</code></pre>
     For example:
-    <pre class="terminal">$ kubectl wait --for=condition=FileSystemResizePending pvc/mysql-data-tanzumysql-sample-0
-    persistentvolumeclaim/mysql-data-tanzumysql-sample-0 condition met <br>
-    $ kubectl rollout restart statefulset tanzumysql-sample
-    statefulset.apps/tanzumysql-sample restarted</pre>
+    <pre class="terminal">$ kubectl wait --for=condition=FileSystemResizePending pvc/mysql-data-mysql-sample-0
+    persistentvolumeclaim/mysql-data-mysql-sample-0 condition met <br>
+    $ kubectl rollout restart statefulset mysql-sample
+    statefulset.apps/mysql-sample restarted</pre>
 
-1. After the StatefulSet controller has automatically re-created the TanzuMySQL Pod, and the TanzuMySQL Pod
+1. After the StatefulSet controller has automatically re-created the MySQL Pod, and the MySQL Pod
 has successfully restarted, verify that the storage has been resized.
 
     ```
     kubectl exec INSTANCE-NAME-N -c mysql -- df -h /var/lib/mysql
     ```
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
-    + `N` is the index of the Pod in the TanzuMySQL instance.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your MySQL resource.
+    + `N` is the index of the Pod in the MySQL instance.
 
     For example:
-    <pre class="terminal">$ kubectl exec tanzumysql-sample-0 -c mysql -- df -h /var/lib/mysql
+    <pre class="terminal">$ kubectl exec mysql-sample-0 -c mysql -- df -h /var/lib/mysql
     Filesystem      Size  Used Avail Use% Mounted on
     /dev/sdb        3.0G  346M  2.6G  12% /var/lib/mysql</pre>
 
@@ -130,12 +130,12 @@ has successfully restarted, verify that the storage has been resized.
 The expected downtime when expanding storage is as follows:
 
 - **With online expansion:** There is no downtime expected in most cases.
-- **With offline expansion:** There is downtime while the TanzuMySQL Pod is re-created and the
+- **With offline expansion:** There is downtime while the MySQL Pod is re-created and the
 PVC is being resized.
 
 ## <a id='scale-resources'></a>Scale CPU and Memory Resources
 
-To scale CPU or memory resources, update the TanzuMySQL configuration `spec.resources` field to change the CPU
+To scale CPU or memory resources, update the MySQL configuration `spec.resources` field to change the CPU
 or memory requirements for the `mysql` or `sidecar` containers.
 
 You can use one of these methods to update the configuration:
@@ -143,21 +143,21 @@ You can use one of these methods to update the configuration:
 * Patch the existing API object in place by running:
 
     ```
-    kubectl patch tanzumysql INSTANCE-NAME --type merge -p \
+    kubectl patch mysql INSTANCE-NAME --type merge -p \
     '{"spec": {"resources": {"mysql": MYSQL-RESOURCES, "sidecar": BACKUP-RESOURCES}}}' \
     ```
 
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your MySQL resource.
     + `MYSQL-RESOURCES` is a collection of `cpu` and `memory` limits and requests for the MySQL container.
     + `BACKUP-RESOURCES` is a collection of `cpu` and `memory` limits and requests for the sidecar container.
 
     For example:
-    <pre class="terminal">$ kubectl patch tanzumysql tanzumysql-sample --type merge -p \
+    <pre class="terminal">$ kubectl patch mysql mysql-sample --type merge -p \
     '{"spec": {"resources": {"mysql": {"requests": {"cpu": "500m"}}, "sidecar": {"limits": {"memory": "64Mi"}}}}}'
     </pre>
 
-* If you manage TanzuMySQL resources with a set of configuration files in source control, you can also
+* If you manage MySQL resources with a set of configuration files in source control, you can also
     change the fields in the file and apply the changes.
 
     For example:
@@ -169,34 +169,34 @@ For more information on managing CPU and Memory resources, see the [Kubernetes d
 
 The expected downtime when changing resource reservations is as follows:
 
-- Brief downtime while Kubernetes re-creates the TanzuMySQL Pods.
+- Brief downtime while Kubernetes re-creates the MySQL Pods.
 - Risk of longer downtime if the new requested values exceed the available capacity
 of the Kubernetes cluster.
 
 ## <a id='other-config'></a>Change Other Configurations
 
 Changing `storageClassName` or `imagePullSecret` does not have any effect on a
-running TanzuMySQL instance.
-If a TanzuMySQL instance is not running due to errors in these fields, you can change them.
+running MySQL instance.
+If a MySQL instance is not running due to errors in these fields, you can change them.
 The changes are propagated into the StatefulSet to correct the error.
 
 To change `storageClassName` or `imagePullSecret`,
-update the TanzuMySQL configuration by one of the methods below:
+update the MySQL configuration by one of the methods below:
 
 * Patch the existing API object in place:
 
     ```
-    kubectl patch tanzumysql INSTANCE-NAME -p '{"spec": {"PROPERTY": "VALUE"}}'
+    kubectl patch mysql INSTANCE-NAME -p '{"spec": {"PROPERTY": "VALUE"}}'
     ```
     Where:
-    + `INSTANCE-NAME` is the value that you configured for metadata.name for your TanzuMySQL resource.
+    + `INSTANCE-NAME` is the value that you configured for metadata.name for your MySQL resource.
     + `PROPERTY` is the property name.
     + `VALUE` is the new property value.
 
     For example:
-    <pre class="terminal">$ kubectl patch tanzumysql tanzumysql-sample -p '{"spec": {"imagePullSecret": "new-secret-name"}}'</pre>
+    <pre class="terminal">$ kubectl patch mysql mysql-sample -p '{"spec": {"imagePullSecret": "new-secret-name"}}'</pre>
 
-* If you manage TanzuMySQL resources with a set of configuration files in source control, you can
+* If you manage MySQL resources with a set of configuration files in source control, you can
     change the fields in the file and apply the changes.
 
     For example:

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -69,7 +69,7 @@ The value of `REGISTRY-URL` has the following pattern:
 1. Go to where the new release has been downloaded and apply the new CRDs by running:
 
     ```
-    kubectl apply -f ./tanzu-mysql-operator/crds/mysql.tanzuvmware.com_crds.yaml
+    kubectl apply -f ./tanzu-mysql-operator/crds/
     ```
 
     <p class="note">


### PR DESCRIPTION
- mysql.tanzu.vmware.com -> sql.tanzu.vmware.com
- TanzuMySQL -> MySQL
- TanzuMySQLBackup -> MySQLBackup
- TanzuMySQLBackupLocation -> MySQLBackupLocation
- TanzuMySQLBackupSchedule -> MySQLBackupSchedule
- TanzuMySQLRestore -> MySQLRestore

Another small change: for upgrading CRDs, I've simplified the instructions to use a directory instead of the exact filename:
```
kubectl apply -f ./tanzu-mysql-operator/crds/
``` 

[#176827765](https://www.pivotaltracker.com/story/show/176827765)

Authored-by: Shaan Sapra <shsapra@vmware.com>

Name the branches to merge this change with or enter "None". **None**
