### PR TITLE
Remove disableSSL property from docs

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -111,7 +111,6 @@ Consequently, creating a MySQLBackupLocation that contains existing artifacts ge
         region: "us-east-1"
         endpoint:  "" # optional, default to AWS
         forcePathStyle: false
-        disableSSL: false
         secret:
           name: backuplocation-sample-creds
   ```

--- a/backup-restore.html.md.erb
+++ b/backup-restore.html.md.erb
@@ -108,7 +108,6 @@ To create a MySQLBackupLocation resource:
       "storage": {
         "s3": {
           "bucket": "bucket-sample",
-          "disableSSL": false,
           "forcePathStyle": false,
           "region": "us-west-1",
           "secret": {

--- a/property-reference-backup-restore.html.md.erb
+++ b/property-reference-backup-restore.html.md.erb
@@ -93,15 +93,6 @@ The table below explains the properties that can be set for the MySQLBackupLocat
   <td><code>false</code></td>
   <td>No</tr>
 </tr>
-<tr>
-  <td>spec.storage.s3.disableSSL</td>
-  <td>boolean</td>
-  <td>false</td>
-  <td>For development environments, set to <code>true</code> to disable SSL for S3 operations.<br>
-      For production environments, set to <code>false</code>.</td>
-  <td><code>false</code></td>
-  <td>No</td>
-</tr>
   <td>spec.storage.s3.secret.name</td>
   <td>String</td>
   <td><em>n/a</em></td>


### PR DESCRIPTION
The purpose of this property was to set the "scheme" for the blob
storage endpoint to "http" rather than the implicit "https" when just a
hostname is provided.

This is a rare use case limited to development, so we have removed this
property.  A user using a blob store that does not support TLS should
specify endpoint: "http://my.endpoint/" instead, which we already
demonstrate in the docs.

[#176718452](https://www.pivotaltracker.com/story/show/176718452)

This change should only be added to main and will only apply to our next release.