### PR TITLE
Rename "cluster" to "instance" when reference to a MySQL instance

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -146,7 +146,7 @@ metadata:
 spec:
   location:
     name: backuplocation-sample
-  cluster:
+  instance:
     name: mysql-sample
 ```
 
@@ -175,7 +175,7 @@ spec:
     spec:
       location:
         name: backuplocation-sample
-      cluster:
+      instance:
         name: mysql-sample
   schedule: "@daily"
 ```

--- a/backup-restore.html.md.erb
+++ b/backup-restore.html.md.erb
@@ -165,7 +165,7 @@ To set a schedule for automatic backups, create a MySQLBackupSchedule resource:
     {
       "backupTemplate": {
         "spec": {
-          "cluster": {
+          "instance": {
             "name": "demo-db"
           },
           "location": {
@@ -468,7 +468,7 @@ for the backup artifacts in the external blobstore.
 To restore to a different namespace or Kubernetes cluster, you create a
 BackupLocation in the target namespace:
 
-1. Target the destination cluster or namespace.
+1. Target the destination Kubernetes cluster or namespace.
 
 1. Create a MySQLBackupLocation resource that contains the backup artifact to restore.
    For how to do this, see [Create a MySQLBackupLocation Resource](#create-backuplocation).

--- a/property-reference-backup-restore.html.md.erb
+++ b/property-reference-backup-restore.html.md.erb
@@ -195,7 +195,7 @@ The table below explains the properties that can be set for the MySQLBackupSched
    <td>Yes</td>
 <tr>
 </tr>
-   <td>spec.backupTemplate.spec.cluster.name</td>
+   <td>spec.backupTemplate.spec.instance.name</td>
    <td>String</td>
    <td><em>n/a</em></td>
    <td>The name of the MySQL instance on which you want scheduled backups for.
@@ -254,7 +254,7 @@ The table below explains the properties that can be set for the MySQLBackup reso
   <td>Yes</td>
 </tr>
 <tr>
-  <td>spec.cluster.name</td>
+  <td>spec.instance.name</td>
   <td>String</td>
   <td><em>n/a</em></td>
   <td>The name of the MySQL instance on which you want to perform the on-demand backup.</td>


### PR DESCRIPTION
To avoid overloading "cluster" further, we now always reference the
deployed MySQL as an "instance" rather than "cluster" within our config
samples.

Updated docs that reference the Tanzu MySQL configuration to replace
"cluster" with "instance". Remaining usage of the word cluster are now
reference a "Kubernetes cluster" or the default Kubernetes system domain
("svc.cluster.local").

[#176718597](https://www.pivotaltracker.com/story/show/176718597)

This change should only be added to main and will only apply to our next release.