### PR TITLE
percona-xtrabackup has been bumped to 8.0.23-16

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -44,7 +44,7 @@ The following components are compatible with this release:
   </tr>
 
   <tr><td>Percona Server</td><td>8.0.22–13</td></tr>
-  <tr><td>Percona XtraBackup</td><td>8.0.22–15</td></tr>
+  <tr><td>Percona XtraBackup</td><td>8.0.23–16</td></tr>
 
 </table>
 


### PR DESCRIPTION
New version to be released in v1.0.0.

[#177485551](https://www.pivotaltracker.com/story/show/177485551)

Only affects v1.0.0 release.