### PR TITLE
Renamed multiple resources

### DIFF
--- a/high-availability.html.md.erb
+++ b/high-availability.html.md.erb
@@ -142,7 +142,7 @@ in _Creating and Deleting MySQL Instances_.
     ```
     where _mysql-ha-sample_ is the MySQL instance `name` defined in the `yaml` manifest file in Step 1.
 
-    The MySQL Operator deploys five MySQL pods: three MySQL engine pods and two mysql-router pods directing traffic to the primary engine pod.
+    The MySQL Operator creates five pods: three MySQL pods and two proxy pods directing traffic to the primary MySQL pod.
 
 3. Verify that the HA MySQL instance was created successfully by running:
 
@@ -159,11 +159,11 @@ NAME              READY   STATUS    AGE
 mysql-ha-sample   true    Running   3m50s
 ```
 
-You can now log into the primary pod mysql using `kubectl exec -it <pod-name> --container=mysql -- bash`. (Because MySQL pods run a sidecar container, you must specify `--container=mysql` to target the mysql engine container.) Execute mysql commands from your local shell by appending mysql commands to the bash command line via `bash -c "mysql ..."`.
- Here is a mysql command exposing the status of the cluster:
-
-You can now log onto mysql pods.
+You can now connect to the primary pod mysql using `kubectl exec -it <pod-name> --container=mysql -- bash`.
+(Because MySQL pods run multiple containers, you must specify `--container=mysql` to target the mysql container.)
+Execute mysql commands from your local shell by appending mysql commands to the bash command line via `bash -c "mysql ..."`.
 For instructions, see [Accessing a Tanzu Mysql for Kubernetes Instance](accessing.html).
+
 You can run commands from your local shell via "kubectl exec"; here is a command exposing the
 status of the cluster:
 

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -143,7 +143,7 @@ The table below explains the properties that you can set in your MySQL resource.
   <td>No</td>
 </tr>
 <tr>
-  <td><code>spec.resources.sidecar</code></td>
+  <td><code>spec.resources.mysqlSidecar</code></td>
   <td>
     <ul>
       <li>limits.cpu</li>
@@ -151,9 +151,9 @@ The table below explains the properties that you can set in your MySQL resource.
     </ul>
   </td>
   <td>Best effort</td>
-  <td>Describes the maximum CPU and memory allowed for the sidecar container.
+  <td>Describes the maximum CPU and memory allowed for the mysql-sidecar container.
       If left blank, Kubernetes does its best effort to allocate the necessary compute resources
-      for the sidecar container.
+      for the mysql-sidecar container.
       For more information about CPU and memory resources,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.
@@ -162,7 +162,7 @@ The table below explains the properties that you can set in your MySQL resource.
   <td>No</td>
 </tr>
 <tr>
-  <td><code>spec.resources.sidecar</code></td>
+  <td><code>spec.resources.mysqlSidecar</code></td>
   <td>
     <ul>
       <li>requests.cpu</li>
@@ -170,7 +170,7 @@ The table below explains the properties that you can set in your MySQL resource.
     </ul>
   </td>
   <td>Best effort</td>
-  <td>Describes the minimum CPU and memory allowed for the sidecar container.
+  <td>Describes the minimum CPU and memory allowed for the mysql-sidecar container.
       If left blank, it defaults to limits if limits have been explicitly specified.
       For more information about limits, see the
       <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
@@ -181,7 +181,7 @@ The table below explains the properties that you can set in your MySQL resource.
   <td>No</td>
 </tr>
 <tr>
-  <td><code>spec.resources.router</code></td>
+  <td><code>spec.resources.proxy</code></td>
   <td>
     <ul>
       <li>limits.cpu</li>
@@ -189,10 +189,10 @@ The table below explains the properties that you can set in your MySQL resource.
     </ul>
   </td>
   <td>Best effort</td>
-  <td>Describes the maximum CPU and memory allowed for the router container. This container is only created when
+  <td>Describes the maximum CPU and memory allowed for the proxy container. This container is only created when
       <code>spec.highAvailability.enabled</code> is specified as <code>true</code>.
       If left blank, Kubernetes does its best effort to allocate the necessary compute resources
-      for the router container.
+      for the proxy container.
       For more information about CPU and memory resources,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.
@@ -201,7 +201,7 @@ The table below explains the properties that you can set in your MySQL resource.
   <td>No</td>
 </tr>
 <tr>
-  <td><code>spec.resources.router</code></td>
+  <td><code>spec.resources.proxy</code></td>
   <td>
     <ul>
       <li>requests.cpu</li>
@@ -209,7 +209,7 @@ The table below explains the properties that you can set in your MySQL resource.
     </ul>
   </td>
   <td>Best effort</td>
-  <td>Describes the minimum CPU and memory allowed for the sidecar container. This container is only created when
+  <td>Describes the minimum CPU and memory allowed for the proxy container. This container is only created when
       <code>spec.highAvailability.enabled</code> is specified as <code>true</code>.
       If left blank, it defaults to limits if limits have been explicitly specified.
       For more information about limits, see the

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -141,16 +141,16 @@ You can use one of these methods to update the configuration:
 
     ```
     kubectl patch mysql INSTANCE-NAME --type merge -p \
-    '{"spec": {"resources": {"mysql": MYSQL-RESOURCES, "sidecar": BACKUP-RESOURCES}}}'
+    '{"spec": {"resources": {"mysql": MYSQL-RESOURCES, " mysqlSidecar": SIDECAR-RESOURCES}}}'
     ```
 
     Where:
     + `INSTANCE-NAME` is the value that you configured for metadata.name for your MySQL resource.
-    + `MYSQL-RESOURCES` is a collection of `cpu` and `memory` limits and requests for the MySQL container.
-    + `BACKUP-RESOURCES` is a collection of `cpu` and `memory` limits and requests for the sidecar container.
+    + `MYSQL-RESOURCES` is a collection of `cpu` and `memory` limits and requests for the `mysql` container.
+    + `SIDECAR-RESOURCES` is a collection of `cpu` and `memory` limits and requests for the `mysql-sidecar` container.
 
     For example:
-    <pre class="terminal">$ kubectl patch mysql mysql-sample --type merge -p '{"spec": {"resources": {"mysql": {"requests": {"cpu": "500m"}}, "sidecar": {"limits": {"memory": "64Mi"}}}}}'
+    <pre class="terminal">$ kubectl patch mysql mysql-sample --type merge -p '{"spec": {"resources": {"mysql": {"requests": {"cpu": "500m"}}, "mysqlSidecar": {"limits": {"memory": "64Mi"}}}}}'
     </pre>
 
 * If you manage MySQL resources with a set of configuration files in source control, you can also


### PR DESCRIPTION
- "spec.resources.sidecar" is now "spec.resources.mysqlSidecar"
- container `mysql-controller` is now `mysql-sidecar`
- continued rename of "router" to "proxy" (when referencing container;
  some "router" references remain when referring to process inside
  container)
- small editorial tweaks

[#177565260](https://www.pivotaltracker.com/story/show/177565260)

Signed-off-by: Kim Bassett <kbassett@pivotal.io>

Name the branches to merge this change with or enter "None".
