### PR TITLE
Update headless service to members service

### DIFF
--- a/high-availability.html.md.erb
+++ b/high-availability.html.md.erb
@@ -176,7 +176,7 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 *************************** 1. row ***************************
   CHANNEL_NAME: group_replication_applier
      MEMBER_ID: 157baa2a-8c22-11eb-847c-0242ac110009
-   MEMBER_HOST: mysql-ha-sample-0.mysql-ha-sample-headless.default.svc.cluster.local
+   MEMBER_HOST: mysql-ha-sample-0.mysql-ha-sample-members.default.svc.cluster.local
    MEMBER_PORT: 3306
   MEMBER_STATE: ONLINE
    MEMBER_ROLE: PRIMARY
@@ -184,7 +184,7 @@ MEMBER_VERSION: 8.0.22
 *************************** 2. row ***************************
   CHANNEL_NAME: group_replication_applier
      MEMBER_ID: 281ad3c9-8c22-11eb-b3aa-0242ac11000a
-   MEMBER_HOST: mysql-ha-sample-1.mysql-ha-sample-headless.default.svc.cluster.local
+   MEMBER_HOST: mysql-ha-sample-1.mysql-ha-sample-members.default.svc.cluster.local
    MEMBER_PORT: 3306
   MEMBER_STATE: ONLINE
    MEMBER_ROLE: SECONDARY
@@ -192,7 +192,7 @@ MEMBER_VERSION: 8.0.22
 *************************** 3. row ***************************
   CHANNEL_NAME: group_replication_applier
      MEMBER_ID: 3c52bb9a-8c22-11eb-aade-0242ac11000b
-   MEMBER_HOST: mysql-ha-sample-2.mysql-ha-sample-headless.default.svc.cluster.local
+   MEMBER_HOST: mysql-ha-sample-2.mysql-ha-sample-members.default.svc.cluster.local
    MEMBER_PORT: 3306
   MEMBER_STATE: ONLINE
    MEMBER_ROLE: SECONDARY


### PR DESCRIPTION
This was done in https://github.com/pivotal-cf/docs-mysql-k8s/pull/37 but somehow the headless service name came back.

[#177485547](https://www.pivotaltracker.com/story/show/177485547)

Co-authored-by: Kim Bassett <kbassett@vmware.com>
Co-authored-by: Shaan Sapra <shsapra@vmware.com>

Name the branches to merge this change with or enter "None".
