### PR TITLE
rename tanzu-mysql-operator chart to tanzu-sql-for-mysql-operator

### DIFF
--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -89,7 +89,7 @@ $ helm chart pull registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-ope
 ref:     <span style="color: #77bf00;">registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.0.0</span>
 digest:  2b6e1d010ab1737dcc5a426b223a06db1c616107d2ceaf368db6fda48d96a61a
 size:    4.2 KiB
-name:    tanzu-mysql-operator
+name:    tanzu-sql-for-mysql-operator
 version: 1.0.0
 Status: Downloaded newer chart for registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.0.0</pre>
   1. **To download `tanzu-mysql-instance`:** Click the artifact from <%= vars.product_network %> and paste the
@@ -114,7 +114,7 @@ faffd54990ce: Pull complete
 Digest: sha256:78073dcf626603da192b78643bda24e0098f944d0bd54da1d60924b20d5eea8c
 Status: Downloaded newer image for registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-instance:1.0.0
 registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-instance:1.0.0</pre>
-  1. **To download `tanzu-mysql-operator`:** Click the artifact from <%= vars.product_network %> and paste the
+  1. **To download the `tanzu-mysql-operator` image:** Click the artifact from <%= vars.product_network %> and paste the
   command into the command line.
   <br><br>For example:
   <pre class="terminal">$ docker pull registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.0.0
@@ -171,7 +171,7 @@ other than registry.pivotal.io, log in to the docker registry:
     ```
     Where `VERSION-NUMBER-TAG` is the version of the Helm chart.
 
-    <br>This downloads a directory named `tanzu-mysql-operator/` into your current working directory that contains:
+    <br>This downloads a directory named `tanzu-sql-for-mysql-operator/` into your current working directory that contains:
     * The <%= vars.product_short %> Helm chart
     * Custom Resource Definitions (CRDs)
     * Role-Based Access Control (RBAC) definitions required to install the Operator with Helm
@@ -181,9 +181,9 @@ other than registry.pivotal.io, log in to the docker registry:
     <br>ref:     registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.0.0
     digest:  2b6e1d010ab1737dcc5a426b223a06db1c616107d2ceaf368db6fda48d96a61a
     size:    4.2 KiB
-    name:    tanzu-mysql-operator
+    name:    tanzu-sql-for-mysql-operator
     version: 1.0.0
-    Exported chart to tanzu-mysql-operator/
+    Exported chart to tanzu-sql-for-mysql-operator/
     </pre>
 
 ### <a id="create-overrides"></a> Review values.yaml and Create Overrides If Needed
@@ -277,11 +277,11 @@ To install the Operator using the Helm CLI:
     Create Overrides If Needed](#create-overrides) above,
     then run the following helm command:
     ```
-    helm install --values=/your/values-override.yaml tanzu-mysql-operator ./tanzu-mysql-operator/
+    helm install --values=/your/values-override.yaml tanzu-sql-for-mysql-operator ./tanzu-sql-for-mysql-operator/
     ```<br><br>
   + If you did not create a `values-override.yaml`, then run the following helm command:
     ```
-    helm install tanzu-mysql-operator ./tanzu-mysql-operator/
+    helm install tanzu-sql-for-mysql-operator ./tanzu-sql-for-mysql-operator/
     ```
 
 1. See that your Operator has installed successfully by running:

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -41,8 +41,8 @@ To upgrade the Operator using the Helm CLI:
 
     <pre class="terminal">
     $ helm -n tanzu-mysql-for-kubernetes-system ls
-    NAME                  NAMESPACE                                REVISION  UPDATED                               STATUS    CHART                       APP VERSION
-    tanzu-mysql-operator  tanzu-tanzu-mysql-for-kubernetes-system  1         2021-01-19 15:52:10.473565 -0700 MST  deployed  tanzu-mysql-operator-1.0.0  1.0.0
+    NAME                    NAMESPACE                               REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
+    tanzu-mysql-operator    tanzu-mysql-for-kubernetes-system       1               2021-04-01 12:15:07.16966 -0500 CDT     deployed        tanzu-sql-with-mysql-operator-1.0.0     1.0.0
     </pre>
 
 1. Download the Helm chart to your current working directory on your local machine by running these commands:
@@ -61,12 +61,12 @@ The value of `REGISTRY-URL` has the following pattern:
     ```
     Where `VERSION-NUMBER-TAG` is the version of the Helm chart.
 
-    <br>This downloads a directory named `tanzu-mysql-operator/` into your current working directory
+    <br>This downloads a directory named `tanzu-sql-for-mysql-operator/` into your current working directory
 
 1. Go to where the new release has been downloaded and apply the new CRDs by running:
 
     ```
-    kubectl apply -f ./tanzu-mysql-operator/crds/
+    kubectl apply -f ./tanzu-sql-for-mysql-operator/crds/
     ```
 
     <p class="note">
@@ -76,14 +76,14 @@ The value of `REGISTRY-URL` has the following pattern:
 1. Upgrade the Operator by running:
 
     ```
-    helm upgrade tanzu-mysql-operator ./tanzu-mysql-operator
+    helm upgrade tanzu-mysql-operator ./tanzu-sql-for-mysql-operator
     ```
 
     When you see `deployed` in the `STATUS` column, the <%= vars.product_short %>
     Helm chart has upgraded:
 
-    <pre class="terminal">$ helm -n tanzu-mysql-for-kubernetes-system history tanzu-mysql-operator
-    REVISION    UPDATED                     STATUS        CHART                              APP VERSION   DESCRIPTION
-    1           Thu Jan 14 17:47:53 2021    superseded    tanzu-mysql-operator-1.0.0         1.0.0          Install complete
-    2           Thu Jan 14 18:09:05 2021    deployed      tanzu-mysql-operator-1.0.1         1.0.1          Upgrade complete
+    <pre class="terminal">$ helm -n tanzu-mysql-for-kubernetes-system history tanzu-sql-for-mysql-operator
+    REVISION    UPDATED                     STATUS        CHART                                  APP VERSION    DESCRIPTION
+    1           Thu Jan 14 17:47:53 2021    superseded    tanzu-sql-for-mysql-operator-1.0.0     1.0.0          Install complete
+    2           Thu Jan 14 18:09:05 2021    deployed      tanzu-sql-for-mysql-operator-1.0.1     1.0.1          Upgrade complete
     </pre>


### PR DESCRIPTION
In an effort to avoid copyright claims around the use of "MySQL", we are
renaming the operator chart.

[#177568103](https://www.pivotaltracker.com/story/show/177568103)

Co-authored-by: Andrew Garner <garnera@vmware.com>
Co-authored-by: Kyle Ong <kyleo@vmware.com>

This only affects the v1.0.0 branch.