### PR TITLE
Rename tanzu-sql-for-mysql-operator to tanzu-sql-with-mysql-operator

### DIFF
--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -89,7 +89,7 @@ $ helm chart pull registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-ope
 ref:     <span style="color: #77bf00;">registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.0.0</span>
 digest:  2b6e1d010ab1737dcc5a426b223a06db1c616107d2ceaf368db6fda48d96a61a
 size:    4.2 KiB
-name:    tanzu-sql-for-mysql-operator
+name:    tanzu-sql-with-mysql-operator
 version: 1.0.0
 Status: Downloaded newer chart for registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.0.0</pre>
   1. **To download `tanzu-mysql-instance`:** Click the artifact from <%= vars.product_network %> and paste the
@@ -171,7 +171,7 @@ other than registry.pivotal.io, log in to the docker registry:
     ```
     Where `VERSION-NUMBER-TAG` is the version of the Helm chart.
 
-    <br>This downloads a directory named `tanzu-sql-for-mysql-operator/` into your current working directory that contains:
+    <br>This downloads a directory named `tanzu-sql-with-mysql-operator/` into your current working directory that contains:
     * The <%= vars.product_short %> Helm chart
     * Custom Resource Definitions (CRDs)
     * Role-Based Access Control (RBAC) definitions required to install the Operator with Helm
@@ -181,9 +181,9 @@ other than registry.pivotal.io, log in to the docker registry:
     <br>ref:     registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.0.0
     digest:  2b6e1d010ab1737dcc5a426b223a06db1c616107d2ceaf368db6fda48d96a61a
     size:    4.2 KiB
-    name:    tanzu-sql-for-mysql-operator
+    name:    tanzu-sql-with-mysql-operator
     version: 1.0.0
-    Exported chart to tanzu-sql-for-mysql-operator/
+    Exported chart to tanzu-sql-with-mysql-operator/
     </pre>
 
 ### <a id="create-overrides"></a> Review values.yaml and Create Overrides If Needed
@@ -277,11 +277,11 @@ To install the Operator using the Helm CLI:
     Create Overrides If Needed](#create-overrides) above,
     then run the following helm command:
     ```
-    helm install --values=/your/values-override.yaml tanzu-sql-for-mysql-operator ./tanzu-sql-for-mysql-operator/
+    helm install --values=/your/values-override.yaml tanzu-sql-with-mysql-operator ./tanzu-sql-with-mysql-operator/
     ```<br><br>
   + If you did not create a `values-override.yaml`, then run the following helm command:
     ```
-    helm install tanzu-sql-for-mysql-operator ./tanzu-sql-for-mysql-operator/
+    helm install tanzu-sql-with-mysql-operator ./tanzu-sql-with-mysql-operator/
     ```
 
 1. See that your Operator has installed successfully by running:

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -61,12 +61,12 @@ The value of `REGISTRY-URL` has the following pattern:
     ```
     Where `VERSION-NUMBER-TAG` is the version of the Helm chart.
 
-    <br>This downloads a directory named `tanzu-sql-for-mysql-operator/` into your current working directory
+    <br>This downloads a directory named `tanzu-sql-with-mysql-operator/` into your current working directory
 
 1. Go to where the new release has been downloaded and apply the new CRDs by running:
 
     ```
-    kubectl apply -f ./tanzu-sql-for-mysql-operator/crds/
+    kubectl apply -f ./tanzu-sql-with-mysql-operator/crds/
     ```
 
     <p class="note">
@@ -76,14 +76,14 @@ The value of `REGISTRY-URL` has the following pattern:
 1. Upgrade the Operator by running:
 
     ```
-    helm upgrade tanzu-mysql-operator ./tanzu-sql-for-mysql-operator
+    helm upgrade tanzu-mysql-operator ./tanzu-sql-with-mysql-operator
     ```
 
     When you see `deployed` in the `STATUS` column, the <%= vars.product_short %>
     Helm chart has upgraded:
 
-    <pre class="terminal">$ helm -n tanzu-mysql-for-kubernetes-system history tanzu-sql-for-mysql-operator
+    <pre class="terminal">$ helm -n tanzu-mysql-for-kubernetes-system history tanzu-sql-with-mysql-operator
     REVISION    UPDATED                     STATUS        CHART                                  APP VERSION    DESCRIPTION
-    1           Thu Jan 14 17:47:53 2021    superseded    tanzu-sql-for-mysql-operator-1.0.0     1.0.0          Install complete
-    2           Thu Jan 14 18:09:05 2021    deployed      tanzu-sql-for-mysql-operator-1.0.1     1.0.1          Upgrade complete
+    1           Thu Jan 14 17:47:53 2021    superseded    tanzu-sql-with-mysql-operator-1.0.0     1.0.0          Install complete
+    2           Thu Jan 14 18:09:05 2021    deployed      tanzu-sql-with-mysql-operator-1.0.1     1.0.1          Upgrade complete
     </pre>


### PR DESCRIPTION
Mistakenly used the wrong preposition for docs in previous PR. We
decided to use "with" to match the current product name.

[#177568103](https://www.pivotaltracker.com/story/show/177568103)

Co-authored-by: Kyle Ong <kyleo@vmware.com>
Co-authored-by: Andrew Garner <garnera@vmware.com>

This only applies to v1.00