### PR TITLE
Update backup/restore columns

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -191,8 +191,8 @@ For example:
 
 <pre class='terminal'>
 $ kubectl get mysqlbackups.with.sql.tanzu.vmware.com
-NAME            STATUS      TIME SCHEDULED                TIME STARTED                  TIME COMPLETED                AGE
-backup-sample   Succeeded   2020-12-07T15:52:12.065092Z   2020-12-07T15:52:12.279522Z   2020-12-07T15:52:16.041156Z   8s
+NAME            STATUS      SOURCE INSTANCE   TIME STARTED           TIME COMPLETED
+backup-sample   Succeeded   mysql-sample      2020-12-07T15:52:12Z   2020-12-07T15:52:16Z
 </pre>
 
 ###<a id="mysqlbackupschedule"></a> MySQLBackupSchedule
@@ -239,7 +239,7 @@ For example:
 apiVersion: with.sql.tanzu.vmware.com/v1
 kind: MySQLRestore
 metadata:
-  name: mysqlrestore-sample
+  name: restore-sample
 spec:
   backup:
     name: backup-sample
@@ -256,8 +256,8 @@ For example:
 
 <pre class='terminal'>
 $ kubectl get mysqlrestores.with.sql.tanzu.vmware.com
-NAME                  STATUS    TIME STARTED                  TIME COMPLETED   AGE
-mysqlrestore-sample   Running   2020-12-07T15:56:26.000000Z                    10s
+NAME             STATUS    SOURCE BACKUP   TARGET INSTANCE   TIME STARTED           TIME COMPLETED
+restore-sample   Running   backup-sample   mysql-sample      2020-12-07T15:56:26Z
 </pre>
 
 The restore retrieves and unpacks the backup artifact and creates the MySQL instance.
@@ -266,8 +266,8 @@ For example:
 
 <pre class='terminal'>
 $ kubectl get mysqlrestores.with.sql.tanzu.vmware.com
-NAME                  STATUS      TIME STARTED                  TIME COMPLETED                AGE
-mysqlrestore-sample   Succeeded   2020-12-07T15:56:26.000000Z   2020-12-07T15:56:41.765479Z   20s
+NAME             STATUS      SOURCE BACKUP   TARGET INSTANCE   TIME STARTED           TIME COMPLETED
+restore-sample   Succeeded   backup-sample   mysql-sample      2020-12-07T15:56:26Z   2020-12-07T15:56:41Z
 </pre>
 
 

--- a/backup-restore.html.md.erb
+++ b/backup-restore.html.md.erb
@@ -246,8 +246,8 @@ To take a backup:
 
     For example:
     <pre  class="terminal">$ kubectl get mysqlbackup backup-sample -n my-namespace
-NAME            STATUS      TIME SCHEDULED                TIME STARTED                  TIME COMPLETED                AGE
-backup-sample   Succeeded   2020-12-01T21:49:26.138676Z   2020-12-01T21:49:26.148835Z   2020-12-01T21:49:30.609250Z   16m
+NAME            STATUS      SOURCE INSTANCE   TIME STARTED           TIME COMPLETED
+backup-sample   Succeeded   mysql-sample      2020-12-01T21:49:26Z   2020-12-01T21:49:30Z
     </pre>
 
     For an explanation of what each column means,
@@ -275,8 +275,8 @@ To see a list of existing MySQLBackup resources:
     For example:
     <pre  class="terminal">
     $ kubectl get mysqlbackup
-    NAME            STATUS   TIME SCHEDULED                TIME STARTED   TIME COMPLETED   AGE
-    backup-sample   Failed   2020-12-09T18:28:23.339156Z                                   23h
+    NAME            STATUS   SOURCE INSTANCE   TIME STARTED   TIME COMPLETED
+    backup-sample   Failed   mysql-sample
     </pre>
 
 2. To understand the output, see the table below:
@@ -294,7 +294,6 @@ To see a list of existing MySQLBackup resources:
                         Allowed values are:
                         <ul>
                            <li>Pending: The backup has been received but not scheduled on a MySQL Pod.</li>
-                           <li>Scheduled: The backup has been scheduled on a selected MySQL Pod but has not started.</li>
                            <li>Running: The backup is being generated and streamed to the external blobstore.</li>
                            <li>Succeeded: The backup has completed successfully.</li>
                            <li>Failed: The backup has failed to complete.
@@ -303,10 +302,10 @@ To see a list of existing MySQLBackup resources:
                         </ul>
                    </td>
               </tr>
-             <tr>
-                   <td><code>TIME SCHEDULED</code></td>
-                   <td> The time at which the backup was scheduled on a selected MySQL Pod.</td>
-             </tr>
+              <tr>
+                    <td><code>SOURCE INSTANCE</code></td>
+                    <td> The MySQL instance the backup was taken from.</td>
+              </tr>
              <tr>
                    <td><code>TIME STARTED</code></td><td> The time that the backup process started.
              </tr>
@@ -314,10 +313,6 @@ To see a list of existing MySQLBackup resources:
                    <td><code>TIME COMPLETED</code></td>
                    <td> The time that the backup process finished.
                         If the backup fails, this value is empty.</td>
-             </tr>
-             <tr>
-                   <td><code>AGE</code></td>
-                   <td>The time since the backup was requested.</td>
              </tr>
     </table>
 
@@ -403,20 +398,20 @@ To restore from a backup:
     For example:
     <pre  class="terminal">
     $ kubectl apply -f testrestore.yaml -n my-namespace
-    mysqlrestore.with.sql.tanzu.vmware.com/mysqlrestore-sample created
+    mysqlrestore.with.sql.tanzu.vmware.com/restore-sample created
     </pre>
 
 5. Verify that a restore has been triggered and track the progress of your restore by running:
 
     ```
-    kubectl get mysqlrestore mysqlrestore-sample -n DEVELOPMENT-NAMESPACE
+    kubectl get mysqlrestore restore-sample -n DEVELOPMENT-NAMESPACE
     ```
 
     For example:
     <pre  class="terminal">
-    $ kubectl get mysqlrestore mysqlrestore-sample -n my-namespace
-    NAME                  STATUS      TIME STARTED                  TIME COMPLETED                AGE
-    mysqlrestore-sample   Succeeded   2020-12-01T21:52:30.000000Z   2020-12-01T21:53:09.163336Z   13m
+    $ kubectl get mysqlrestore restore-sample -n my-namespace
+    NAME             STATUS      SOURCE BACKUP   TARGET INSTANCE   TIME STARTED           TIME COMPLETED
+    restore-sample   Succeeded   backup-sample   mysql-sample      2020-12-01T21:52:30Z   2020-12-01T21:53:09Z
    </pre>
 
 6. To understand the output, see the table below:
@@ -434,27 +429,31 @@ To restore from a backup:
                         <ul>
                            <li>Pending: The restore has been received but not yet scheduled
                                on a MySQL Pod.</li>
-                           <li>Scheduled: The restore has been scheduled but has not started.</li>
                            <li>Running: The restore is in progress.</li>
                            <li>Succeeded: The restore has completed successfully.</li>
                            <li>Failed: The restore failed.
                                To troubleshoot, see <a href="#troubleshoot">Troubleshoot
                                Backup and Restore</a> below.</li>
                         </ul>
-                   </td>
-              </tr>
-             <tr>
-                   <td><code>TIME STARTED</code></td><td> The time that the restore process started.
-             </tr>
-             <tr>
-                   <td><code>TIME COMPLETED</code></td>
-                   <td> The time that the restore process finished.
-                        If the restore fails, this value is empty.</td>
-             </tr>
-             <tr>
-                   <td><code>AGE</code></td>
-                   <td>The time since the restore was requested.</td>
-             </tr>
+                    </td>
+            </tr>
+            <tr>
+                    <td><code>SOURCE BACKUP</code>
+                    <td> The name of the backup being restored.
+            </tr>
+            <tr>
+                    <td><code>TARGET INSTANCE</code>
+                    <td> The name of the new MySQL instance to be restored with the backup contents.
+            </tr>
+            <tr>
+                    <td><code>TIME STARTED</code>
+                    <td> The time that the restore process started.
+            </tr>
+            <tr>
+                    <td><code>TIME COMPLETED</code>
+                    <td> The time that the restore process finished.
+                        If the restore fails, this value is empty.
+            </tr>
     </table>
 
 ###<a id="restore-to-different"></a> Restoring a Backup to a Different Namespace or Kubernetes Cluster
@@ -480,8 +479,8 @@ BackupLocation in the target namespace:
    For example:
    <pre class='terminal'>
    $ kubectl get mysqlbackup
-     NAME            STATUS      TIME SCHEDULED                TIME STARTED                  TIME COMPLETED                AGE
-     sample-backup   Succeeded   2020-12-01T21:49:26.138676Z   2020-12-01T21:49:26.148835Z   2020-12-01T21:49:30.609250Z   5d17h
+     NAME            STATUS      SOURCE INSTANCE   TIME STARTED           TIME COMPLETED
+     sample-backup   Succeeded   mysql-sample      2020-12-01T21:49:26Z   2020-12-01T21:49:30Z
    </pre>
 
 1. Trigger a restore by following steps in [Restore from a Backup](#restore-from-backup).
@@ -504,8 +503,8 @@ To troubleshoot problems with backup and restore:
 
     <pre class="terminal">
     $ kubectl get mysqlbackup backup-sample
-    NAME            STATUS   TIME SCHEDULED                TIME STARTED   TIME COMPLETED   AGE
-    backup-sample   Failed   2020-12-09T18:28:23.339156Z                                   2m44s
+    NAME            STATUS   SOURCE INSTANCE   TIME STARTED   TIME COMPLETED
+    backup-sample   Failed   mysql-sample
    </pre>
 
 2. Diagnose the issue by inspecting the Kubernetes events for the resource, for example:

--- a/property-reference-backup-restore.html.md.erb
+++ b/property-reference-backup-restore.html.md.erb
@@ -279,7 +279,7 @@ The table below explains the properties that can be set for the MySQLRestore res
   <td>String</td>
   <td><em>n/a</em></td>
   <td>The name of the MySQLRestore. Must be unique within a namespace.</td>
-  <td><code>mysqlrestore-sample</code></td>
+  <td><code>restore-sample</code></td>
   <td>Yes</td>
 </tr>
 <tr>
@@ -315,4 +315,3 @@ spec:
   storageSize: 1Gi
   imagePullSecret: tanzu-mysql-image-registry
 </pre>
-


### PR DESCRIPTION
- Time columns no longer include microseconds
- Removed "AGE" columns
- Removed "Scheduled" status
- Backups:
  - Removed "TIME SCHEDULED"
  - Added "SOURCE INSTANCE"
- Restores:
  - Added "SOURCE BACKUP" and "TARGET INSTANCE"
  - Replace sample name: mysqlrestore-sample -> restore-sample

[#176718745](https://www.pivotaltracker.com/story/show/176718745)

Co-authored-by: David Sharp <dsharp@vmware.com>
Co-authored-by: Kevin Markwardt <kmarkwardt@vmware.com>

Name the branches to merge this change with or enter "None".
None
