### PR TITLE
Restructure the Property Reference table

### DIFF
--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -22,7 +22,9 @@ The table below explains the properties that you can set in your MySQL resource.
 <tr>
   <td><code>metadata.name</code></td>
   <td>The name of the MySQL instance. Must be unique within a namespace. Cannot be updated. For more information, see the <a href="http://kubernetes.io/docs/user-guide/identifiers#names">Kubernetes documentation</a>.<br /><br />
-  Type: String. Required. Default: <em>n/a</em>.
+  <strong>Type:</strong> String.<br />
+  <strong>Required.</strong><br />
+  <strong>Default:</strong> <em>n/a</em>.
       </td>
   <td><code>my&#8209;instance</code></td>
 </tr>
@@ -32,7 +34,9 @@ The table below explains the properties that you can set in your MySQL resource.
       For information about allowed size units, see discussion about resource quantities in
       the <a href="https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#resource-quantities">
       kubernetes / community</a> GitHub repository.<br /><br />
-      Type: Resource quantity.  Required. Default: <em>n/a</em>.
+      <strong>Type:</strong> Resource quantity.<br />
+      <strong>Required.</strong><br />
+      <strong>Default:</strong> <em>n/a</em>.
   </td>
   <td><code>50Gi</code></td>
 </tr>
@@ -40,7 +44,9 @@ The table below explains the properties that you can set in your MySQL resource.
   <td><code>spec.imagePullSecret</code></td>
   <td>An existing Kubernetes docker-registry secret that can access the
   registry containing the MySQL image.<br /><br />
-  Type: String. Required. Default: <em>n/a</em>.</td>
+  <strong>Type:</strong> String.<br />
+  <strong>Required.</strong><br />
+  <strong>Default:</strong> <em>n/a</em>.</td>
   <td><code>tanzu-mysql-image-registry</code></td>
 </tr>
 <tr>
@@ -50,7 +56,9 @@ The table below explains the properties that you can set in your MySQL resource.
       For information about the StorageClass concept, see the
       <a href="https://kubernetes.io/docs/concepts/storage/storage-classes/">
       Kubernetes documentation</a>.<br /><br />
-    Type: String. Optional. Default: Standard.</td>
+      <strong>Type:</strong> String.<br />
+      <strong>Optional.</strong><br />
+      <strong>Default:</strong> Standard.</td>
   <td><code>standard</code></td>
 </tr>
 <tr>
@@ -60,13 +68,17 @@ The table below explains the properties that you can set in your MySQL resource.
       For more information about Kubernetes ServiceTypes, see the
       <a href="https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types">
       Kubernetes documentation</a>.<br /><br />
-  Type: String. Optional. Default: ClusterIP.</td>
+      <strong>Type:</strong> String.<br />
+      <strong>Optional.</strong><br />
+      <strong>Default:</strong> ClusterIP.</td>
   <td><code>LoadBalancer</code></td>
 </tr>
 <tr>
   <td><code>spec.tls.secret.name</code></td>
   <td>The name of the Kubernetes secret containing the TLS certificate and private key used to support encrypted connections by clients.<br /><br />
-  Type: String. Optional. Default: <em>n/a</em>.</td>
+  <strong>Type:</strong> String.<br />
+  <strong>Optional.</strong><br />
+  <strong>Default:</strong> <em>n/a</em>.</td>
   <td><code>mysql-tls-secret</code></td>
 </tr>
 <tr>
@@ -74,7 +86,9 @@ The table below explains the properties that you can set in your MySQL resource.
   <td>
   Whether the instance is a high-availability cluster (not single-node).
   For information about high availability, see <a href="high-availability.html">Configuring MySQL Instances for High Availability</a>.<br /><br />
-  Type: Boolean. Optional. Default: False.</td>
+  <strong>Type:</strong> Boolean.<br />
+  <strong>Optional.</strong><br />
+  <strong>Default:</strong> False.</td>
   <td><code>highAvailability.enabled: false</code></td>
 </tr>
 <tr>
@@ -86,7 +100,9 @@ The table below explains the properties that you can set in your MySQL resource.
       For more information about managing resources for containers,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.<br /><br />
-  Type: limits.cpu, limits.memory. Optional. Default: Best effort.</td>
+      <strong>Type:</strong> limits.cpu, limits.memory.<br />
+      <strong>Optional.</strong><br />
+      <strong>Default:</strong> Best effort.</td>
   <td><code>limits.cpu: 3 , limits.memory: 800Mi</code></td>
 </tr>
 <tr>
@@ -97,7 +113,9 @@ The table below explains the properties that you can set in your MySQL resource.
       For more information about limits, see the
       <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.<br /><br />
-  Type: requests.cpu, requests.memory. Optional. Default: Best effort.</td>
+      <strong>Type:</strong> requests.cpu, requests.memory.<br />
+      <strong>Optional.</strong><br />
+      <strong>Default:</strong> Best effort.</td>
   <td><code>requests.cpu: 2 , requests.memory: 500Mi</code></td>
 </tr>
 <tr>
@@ -108,7 +126,9 @@ The table below explains the properties that you can set in your MySQL resource.
       For more information about CPU and memory resources,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.<br /><br /> 
-  Type: limits.cpu, limits.memory.Optional. Default: Best effort.</td>
+      <strong>Type:</strong> limits.cpu, limits.memory.<br />
+      <strong>Optional.</strong><br />
+      <strong>Default:</strong> Best effort.</td>
   <td><code>limits.cpu: 2 , limits.memory: 500Mi</code></td>
 </tr>
 <tr>
@@ -118,7 +138,9 @@ The table below explains the properties that you can set in your MySQL resource.
       For more information about limits, see the
       <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.<br /><br />
-      Type: requests.cpu, requests.memory. Optional. Default: Best effort.</td>
+      <strong>Type:</strong> requests.cpu, requests.memory.<br />
+      <strong>Optional.</strong><br />
+      <strong>Default:</strong> Best effort.</td>
   <td><code>requests.cpu:&nbsp;1&nbsp;, requests.memory:&nbsp;200Mi</code>
   </td>
 </tr>
@@ -131,7 +153,9 @@ The table below explains the properties that you can set in your MySQL resource.
       For more information about CPU and memory resources,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.<br /><br />
-    Type: limits.cpu, limits.memory. Optional. Default: Best effort.</td>
+      <strong>Type:</strong> limits.cpu, limits.memory.<br />
+      <strong>Optional.</strong><br />
+      <strong>Default:</strong> Best effort.</td>
   <td><code>limits.cpu: 1000m, limits.memory: 256Mi</code></td>
 </tr>
 <tr>
@@ -142,7 +166,9 @@ The table below explains the properties that you can set in your MySQL resource.
       For more information about limits, see the
       <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
       Kubernetes documentation</a>.<br /><br />
-  Type: requests.cpu, requests.memory. Optional. Default: Best effort.</td>
+      <strong>Type:</strong> requests.cpu, requests.memory.<br />
+      <strong>Optional.</strong><br />
+      <strong>Default:</strong> Best effort.</td>
   <td><code>requests.cpu: 200m;, requests.memory: 48Mi</code>
   </td>
 </tr>

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -5,219 +5,145 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-This topic is a property reference table for the MySQL resource.
+This topic contains a property reference table for the MySQL resource.
 Refer to this table when you are creating the YAML file for a MySQL instance.
 For more information, see [Create a Mysql Instance](create-delete-mysql.html#create-instance) in
 _Creating and Deleting a MySQL Instance_.
 
 The table below explains the properties that you can set in your MySQL resource.
 
-<table style="width:1000px" class="nice">
-<col width="15%">
-<col width="15%">
-<col width="10%">
-<col width="37%">
-<col width="15%">
-<col width="8%">
+<table class="nice">
+<col width="20%">
+<col width="60%">
+<col width="20%">
 <th>Property</th>
-<th>Type</th>
-<th>Default</th>
-<th>Description</th>
+<th>Information</th>
 <th>Example</th>
-<th>Required?</th>
 <tr>
   <td><code>metadata.name</code></td>
-  <td>String</td>
-  <td><em>n/a</em></td>
-  <td>The name of your MySQL instance:<br><br>
-      <ul>
-         <li>Must be unique within a namespace</li>
-         <li>Cannot be updated</li>
-         <li>Required when creating resources, although some resources might allow a client
-             to request the generation of an appropriate name automatically</li>
-      </ul>
-      Name is primarily intended for creation idempotence and configuration definition.
-      For more information about Name, see the <a href="http://kubernetes.io/docs/user-guide/identifiers#names">
-      Kubernetes documentation</a>.</td>
+  <td>The name of the MySQL instance. Must be unique within a namespace. Cannot be updated. For more information, see the <a href="http://kubernetes.io/docs/user-guide/identifiers#names">Kubernetes documentation</a>.<br /><br />
+  Type: String. Required. Default: <em>n/a</em>.
+      </td>
   <td><code>my&#8209;instance</code></td>
-  <td>Yes</td>
 </tr>
 <tr>
   <td><code>spec.storageSize</code></td>
-  <td>Resource quantity</td>
-  <td><em>n/a</em></td>
-  <td>StorageSize specifies the size of the persistent volume claims (PVCs) for the <%= vars.product_short %> Pods.
-      For information about the units allowed for these PVC sizes, see about resource quantities in
-      <a href="https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#resource-quantities">
-      kubernetes / community</a> in GitHub.
+  <td>The size of the persistent volume claims (PVCs) for MySQL instance Pods.
+      For information about allowed size units, see discussion about resource quantities in
+      the <a href="https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#resource-quantities">
+      kubernetes / community</a> GitHub repository.<br /><br />
+      Type: Resource quantity.  Required. Default: <em>n/a</em>.
   </td>
   <td><code>50Gi</code></td>
-  <td>Yes</td>
 </tr>
 <tr>
   <td><code>spec.imagePullSecret</code></td>
-  <td>String</td>
-  <td><em>n/a</em></td>
-  <td>Refers to an existing Kubernetes docker-registry secret that can access the
-    registry that contains the MySQL image.</td>
+  <td>An existing Kubernetes docker-registry secret that can access the
+  registry containing the MySQL image.<br /><br />
+  Type: String. Required. Default: <em>n/a</em>.</td>
   <td><code>tanzu-mysql-image-registry</code></td>
-  <td>Yes</td>
 </tr>
 <tr>
   <td><code>spec.storageClassName</code></td>
-  <td>String</td>
-  <td>Standard</td>
-  <td>Specifies the StorageClass for the PVCs for the <%= vars.product_short %> Pods.
-      For the types of StorageClasses available, contact your Kubernetes admin.
-      For more information about the Kubernetes StorageClass concept, see the
+  <td>The StorageClass used for PVCs associated with MySQL instance Pods.
+      For available types, contact your Kubernetes admin.
+      For information about the StorageClass concept, see the
       <a href="https://kubernetes.io/docs/concepts/storage/storage-classes/">
-      Kubernetes documentation</a>.</td>
+      Kubernetes documentation</a>.<br /><br />
+    Type: String. Optional. Default: Standard.</td>
   <td><code>standard</code></td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.serviceType</code></td>
-  <td>String</td>
-  <td>ClusterIP</td>
-  <td>Specifies the type of Service used to provide access to the MySQL database.
+  <td>The type of Service used to provide access to the MySQL database.
       Only <code>ClusterIP</code> and <code>LoadBalancer</code> are supported.
-      For more information about the Kubernetes ServiceTypes, see the
+      For more information about Kubernetes ServiceTypes, see the
       <a href="https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types">
-      Kubernetes documentation</a>.</td>
+      Kubernetes documentation</a>.<br /><br />
+  Type: String. Optional. Default: ClusterIP.</td>
   <td><code>LoadBalancer</code></td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.tls.secret.name</code></td>
-  <td>String</td>
-  <td><em>n/a</em></td>
-  <td>The name of the Kubernetes secret that contains the TLS certificate and private key to support encrypted connections by clients.
-  </td>
+  <td>The name of the Kubernetes secret containing the TLS certificate and private key used to support encrypted connections by clients.<br /><br />
+  Type: String. Optional. Default: <em>n/a</em>.</td>
   <td><code>mysql-tls-secret</code></td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.highAvailability.enabled</code></td>
-  <td>Boolean</td>
-  <td>False</td>
-  <td>Specifies whether the instance will be a single node or a high-availability multi-node cluster.
-  For more information about high availability, see <a href="high-availability.html">Configuring MySQL Instances for High Availability</a>.
-  </td>
+  <td>
+  Whether the instance is a high-availability cluster (not single-node).
+  For information about high availability, see <a href="high-availability.html">Configuring MySQL Instances for High Availability</a>.<br /><br />
+  Type: Boolean. Optional. Default: False.</td>
   <td><code>highAvailability.enabled: false</code></td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.resources.mysql</code></td>
   <td>
-    <ul>
-      <li>limits.cpu</li>
-      <li>limits.memory</li>
-    </ul>
-  </td>
-  <td>Best effort</td>
-  <td>Describes the maximum CPU and memory allowed for the MySQL container.
-      If left blank, Kubernetes does its best effort to allocate necessary compute resources
-      for the MySQL container.
+  The maximum CPU and memory allowed for the MySQL container.
+      If not specified, Kubernetes does its best effort to allocate necessary compute resources
+      for this container.
       For more information about managing resources for containers,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
-      Kubernetes documentation</a>.</td>
+      Kubernetes documentation</a>.<br /><br />
+  Type: limits.cpu, limits.memory. Optional. Default: Best effort.</td>
   <td><code>limits.cpu: 3 , limits.memory: 800Mi</code></td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.resources.mysql</code></td>
   <td>
-    <ul>
-      <li>requests.cpu</li>
-      <li>requests.memory</li>
-    </ul>
-  </td>
-  <td>Best effort</td>
-  <td>Describes the minimum CPU and memory allowed for the MySQL container.
-      If left blank, it defaults to limits if limits have been explicitly specified.
+  The minimum CPU and memory allowed for the MySQL container.
+      If not specified, defaults to limits, if limits have been explicitly specified.
       For more information about limits, see the
       <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
-      Kubernetes documentation</a>.
-  </td>
+      Kubernetes documentation</a>.<br /><br />
+  Type: requests.cpu, requests.memory. Optional. Default: Best effort.</td>
   <td><code>requests.cpu: 2 , requests.memory: 500Mi</code></td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.resources.mysqlSidecar</code></td>
-  <td>
-    <ul>
-      <li>limits.cpu</li>
-      <li>limits.memory</li>
-    </ul>
-  </td>
-  <td>Best effort</td>
-  <td>Describes the maximum CPU and memory allowed for the mysql-sidecar container.
-      If left blank, Kubernetes does its best effort to allocate the necessary compute resources
-      for the mysql-sidecar container.
+  <td>The maximum CPU and memory allowed for the mysql-sidecar container.
+      If not specified, Kubernetes does its best effort to allocate the necessary compute resources
+      for this container.
       For more information about CPU and memory resources,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
-      Kubernetes documentation</a>.
-  </td>
+      Kubernetes documentation</a>.<br /><br /> 
+  Type: limits.cpu, limits.memory.Optional. Default: Best effort.</td>
   <td><code>limits.cpu: 2 , limits.memory: 500Mi</code></td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.resources.mysqlSidecar</code></td>
-  <td>
-    <ul>
-      <li>requests.cpu</li>
-      <li>requests.memory</li>
-    </ul>
-  </td>
-  <td>Best effort</td>
   <td>Describes the minimum CPU and memory allowed for the mysql-sidecar container.
-      If left blank, it defaults to limits if limits have been explicitly specified.
+      If left blank, defaults to limits, if limits have been explicitly specified.
       For more information about limits, see the
       <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
-      Kubernetes documentation</a>.
-  </td>
+      Kubernetes documentation</a>.<br /><br />
+      Type: requests.cpu, requests.memory. Optional. Default: Best effort.</td>
   <td><code>requests.cpu:&nbsp;1&nbsp;, requests.memory:&nbsp;200Mi</code>
   </td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.resources.proxy</code></td>
-  <td>
-    <ul>
-      <li>limits.cpu</li>
-      <li>limits.memory</li>
-    </ul>
-  </td>
-  <td>Best effort</td>
-  <td>Describes the maximum CPU and memory allowed for the proxy container. This container is only created when
-      <code>spec.highAvailability.enabled</code> is specified as <code>true</code>.
-      If left blank, Kubernetes does its best effort to allocate the necessary compute resources
+  <td>Describes the maximum CPU and memory allowed for the proxy container. This container is only created if
+      <code>spec.highAvailability.enabled</code> is <code>true</code>.
+      If not specified, Kubernetes does its best effort to allocate the necessary compute resources
       for the proxy container.
       For more information about CPU and memory resources,
       see the <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
-      Kubernetes documentation</a>.
-  </td>
+      Kubernetes documentation</a>.<br /><br />
+    Type: limits.cpu, limits.memory. Optional. Default: Best effort.</td>
   <td><code>limits.cpu: 1000m, limits.memory: 256Mi</code></td>
-  <td>No</td>
 </tr>
 <tr>
   <td><code>spec.resources.proxy</code></td>
-  <td>
-    <ul>
-      <li>requests.cpu</li>
-      <li>requests.memory</li>
-    </ul>
-  </td>
-  <td>Best effort</td>
-  <td>Describes the minimum CPU and memory allowed for the proxy container. This container is only created when
-      <code>spec.highAvailability.enabled</code> is specified as <code>true</code>.
-      If left blank, it defaults to limits if limits have been explicitly specified.
+  <td>Describes the minimum CPU and memory allowed for the proxy container. This container is only created if
+      <code>spec.highAvailability.enabled</code> is <code>true</code>.
+      If not specified, defaults to limits, if limits have been explicitly specified.
       For more information about limits, see the
       <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/">
-      Kubernetes documentation</a>.
-  </td>
+      Kubernetes documentation</a>.<br /><br />
+  Type: requests.cpu, requests.memory. Optional. Default: Best effort.</td>
   <td><code>requests.cpu: 200m;, requests.memory: 48Mi</code>
   </td>
-  <td>No</td>
 </tr>
 </table>


### PR DESCRIPTION
I did remove some info from the 'Description' (now 'Information') text of one or two rows, because the table was fairly unwieldy. I attempted to preserve everything possible but simplify.

We do need to restructure the table in some way, because as is, it flows beyond the content area and the right-hand nav obscures part of the table as you scroll.