### PR TITLE
“Installing the Operator": add section about install based on downloaded archive

### DIFF
--- a/configure-tls.html.md.erb
+++ b/configure-tls.html.md.erb
@@ -100,7 +100,7 @@ To create the TLS Secret through the kubectl instead,
 see [Create the TLS Secret Manually](#create-tls-secret) above.
 
 
-1. If you have not installed cert-manager on your Kubernetes cluster during the [Installing the Tanzu SQL for Kubernetes Operator - Prerequisites](install-operator.html#prereq), install it by running these commands:
+1. If you have not yet installed cert-manager on your Kubernetes cluster, install it by running these commands:
 
     ```
     kubectl create namespace cert-manager

--- a/connecting-apps.html.md.erb
+++ b/connecting-apps.html.md.erb
@@ -61,7 +61,7 @@ Application configuration will be specific to the app being deployed. This secti
 
 This section assumes that the MySQL instance is named `mysql-sample` and is deployed to the `default` Kubernetes namespace.
 
-1. Install cert-manager if it is not already present in the cluster following the details in [Installing the Tanzu SQL for Kubernetes Operator - Prerequisites](install-operator.html#prereq). 
+1. Install cert-manager if it is not already present in the cluster following the details in [Installing the Tanzu SQL for Kubernetes Operator](./install-operator.html). 
 
 1. Generate a certificate for MySQL to present to WordPress. The certificate must meet the WordPress authentication requirements.
     <br /><br />

--- a/connecting-apps.html.md.erb
+++ b/connecting-apps.html.md.erb
@@ -61,7 +61,7 @@ Application configuration will be specific to the app being deployed. This secti
 
 This section assumes that the MySQL instance is named `mysql-sample` and is deployed to the `default` Kubernetes namespace.
 
-1. Install cert-manager if it is not already present in the cluster following the details in [Installing the Tanzu SQL for Kubernetes Operator](./install-operator.html). 
+1. Install cert-manager if it is not already present in the cluster, following the details in [Prerequisites for Installing via the Tanzu Network Registry](./install-operator.html#tanzu-network-prerequisites).
 
 1. Generate a certificate for MySQL to present to WordPress. The certificate must meet the WordPress authentication requirements.
     <br /><br />

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -26,7 +26,9 @@ Before you deploy the Tanzu MySQL operator, you need:
 
 - [Docker](https://github.com/docker) running and configured on your local computer, to access the Kubernetes cluster and Docker registry.
 
-- A running Kubernetes cluster - [Google Kubernetes Engine (GKE)](prepare-gke.html), [VMware Enterprise TKGi)](prepare-pks.html) or [Minikube](minikube.html) - and the [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) command-line tool, configured and authenticated to communicate with your Kubernetes cluster. If you are using GKE, install the [gcloud](https://cloud.google.com/sdk/gcloud/) command-line tool on your local client.
+- A running Kubernetes cluster.
+
+- The [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) command-line tool, configured and authenticated to communicate with your Kubernetes cluster.
 
 - The Helm v3 command-line tool installed. For more information, see [Installing Helm](https://helm.sh/docs/intro/install/) from the Helm documentation.
 
@@ -305,7 +307,7 @@ $ docker push ${OPERATOR_IMAGE_NAME}
 
 Create a `docker-registry` type secret to allow the Kubernetes cluster to authenticate with the private container registry so it can pull images. These examples create a secret named `tanzu-image-registry` using Harbor, Google Cloud Registry (GCR), and Amazon Elastic Container Registry (ECR). 
 
-**IMPORTANT**: The commands below create the secret in the `default` namespace. Only pods created in the same `default` namespace can reference the secret. To create a secret in a different namespace, use the `--namespace` flag.
+<p class='note important'><strong>Important:</strong> The commands below create the secret in the current configured namespace for the kubectl context. Only pods created in the same namespace can reference the secret. To create a secret in a different namespace, use the `--namespace` flag. You should create an identical secret in the operator namespace and in each namespace where you will create Tanzu MySQL instances.</p>
 
 **Harbor**
 
@@ -439,11 +441,12 @@ resources: {}
     
     ``` bash
     $ helm install --wait my-mysql-operator charts/tanzu-sql-with-mysql-operator/ \
-      --namespace=${OPERATOR_NAMESPACE} \
-      --create-namespace \   
+      --values=operator-values-overrides.yaml \
+      --namespace=mysql-for-kubernetes-system \
+      --create-namespace
     ```
 
-    Helm installs the new release into the Kubernetes namespace specified in the current Kubernetes context. The command displays a message similar to:
+    The command displays a message similar to:
 
     ```
     NAME: my-mysql-operator

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -18,7 +18,7 @@ This section describes how to access the resources, and deploy the <%=vars.produ
 To install the Tanzu MySQL operator, you must use kubectl to create a namespace and secret.
 Then, use the Helm CLI to install the operator.
 
-### <a id='tanzu-network-prerequisites'></a>Prerequisites
+### <a id='tanzu-network-prerequisites'></a>Prerequisites for Installing via the Tanzu Network Registry
 
 Before you deploy the Tanzu MySQL operator, you need:
 
@@ -236,7 +236,7 @@ This section covers:
 - Configuring a Kubernetes secret for accessing the private container registry
 - Deploying the MySQL operator
 
-### <a id="download-archive-prerequisites"></a>Prerequisites
+### <a id="download-archive-prerequisites"></a>Prerequisites for Installing via a Downloaded Archive File
 
 Before you deploy the <%=vars.product_full %> Operator, review the list of [Prerequisites](#prereq) that apply to both installation methods. 
 

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -5,45 +5,29 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-This topic describes how Kubernetes admins install, configure,
-and deploy the <%= vars.product_full %> operator.
+This topic describes how to install <%= vars.product_full %> using two different methods. 
 
-## <a id="overview"></a> Overview
+- Use [Installing Tanzu MySQL Operator via Tanzu Network Registry](#install-via-tanzu) for a faster installation process, and if your server hosts have access to the internet. 
 
-[//]: # (Rewrite or replace by a process after this page has been reworked.)
+- Use [Installing Tanzu MySQL Operator via Downloadable Archive File](install-operator.html#install-via-tar) if your server hosts do not have access to the internet, or if you want to install from a private registry.
 
-To install and configure <%= vars.product_short %>, you must download resources using Docker and Helm.
-You will complete the installation of the <%= vars.product_short %> operator using Helm.
+## <a id="install-via-tanzu"></a>Install Tanzu MySQL Operator via the Tanzu Network Registry
 
-To download resources and install the operator:
+This section describes how to access the resources, and deploy the <%=vars.product_full %> Operator using the Tanzu Network Registry. 
 
-1. [Download the Resources](#download)
-1. [Install the Operator](#install)
- 1. [Create Namespace and Secret](#create-namespace-secret)
- 2. [Review values.yaml and Create Overrides If Needed](#create-overrides)
- 1. [Use Helm CLI to Install the Operator](#install-operator)
+### <a id='tanzu-prereq'></a>Prerequisites
 
-## <a id='prereq'></a>Prerequisites
+Before you deploy the Tanzu MySQL operator, you need:
 
-Before you deploy the <%= vars.product_short %> operator, you need:
+- Access to [Tanzu Network](https://network.pivotal.io) and [Tanzu Network Registry](https://registry.pivotal.io/). You can use the same credentials for both sites.
 
-* Access to [<%= vars.product_network %>](https://network.pivotal.io)
-  and [<%= vars.product_network %> Registry](https://registry.pivotal.io/).
-  Use the same credentials for both.
+- [Docker](https://github.com/docker) running and configured on your local computer, to access the Kubernetes cluster and Docker registry.
 
-* The Helm v3 command-line tool installed. For more information, see [Installing
-  Helm](https://helm.sh/docs/intro/install/) from the Helm documentation.
+- A running Kubernetes cluster - [Google Kubernetes Engine (GKE)](prepare-gke.html), [VMware Enterprise TKGi)](prepare-pks.html) or [Minikube](minikube.html) - and the [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) command-line tool, configured and authenticated to communicate with your Kubernetes cluster. If you are using GKE, install the [gcloud](https://cloud.google.com/sdk/gcloud/) command-line tool on your local client.
 
-* Docker running and configured on your local computer, to access the Kubernetes cluster and Docker registry.
-  For information, see the [Docker documentation](https://docs.docker.com/).
+- The Helm v3 command-line tool installed. For more information, see [Installing Helm](https://helm.sh/docs/intro/install/) from the Helm documentation.
 
-* A running Kubernetes cluster.
-
-* The kubectl command-line tool, configured and authenticated to communicate with your Kubernetes cluster.
-For more information, see [Install Tools](https://kubernetes.io/docs/tasks/tools/install-kubectl/) in the Kubernetes documentation.
-
-* `cluster-admin` ClusterRole access to the Kubernetes cluster.
-For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) in the Kubernetes documentation.
+- `cluster-admin` ClusterRole access to the Kubernetes cluster. For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).
 
 * [Cert Manager](https://github.com/jetstack/cert-manager) installed on the Kubernetes cluster. 
     
@@ -91,9 +75,9 @@ For more information, see [User-facing roles](https://kubernetes.io/docs/referen
     
     For more advanced security scenarios, see [Configuring TLS for MySQL Instances](configure-tls.html). 
 
-## <a id="download"></a> Download the Resources
+## <a id="access"></a> Access the Resources
 
-To install the <%= vars.product_short %> operator, you must download the Helm chart and images.
+To install the Tanzu MySQL operator, you must download the Helm chart and images.
 
 To download the resources:
 
@@ -169,9 +153,9 @@ Digest: sha256:91664f6866b7228b68d3fb9ff8e13af95f618b7b78e5fd35690dd29394a08db1
 Status: Downloaded newer image for registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.1.0
 registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.1.0</pre>
 
-## <a id="install"></a> Install the Operator
+### <a id="install"></a> Install the Operator
 
-To install the <%= vars.product_short %> operator, you must use kubectl to create a namespace and secret.
+To install the Tanzu MySQL operator, you must use kubectl to create a namespace and secret.
 Then, use the Helm CLI to install the operator.
 
 ### <a id="create-namespace-secret"></a> Create Namespace and Secret
@@ -188,13 +172,13 @@ To create the namespace and secret:
     ```
     kubectl config set-context --current --namespace tanzu-mysql-for-kubernetes-system
     ```
-3. If you want to deploy the <%= vars.product_short %> images from a registry
+3. If you want to deploy the Tanzu MySQL images from a registry
 other than registry.pivotal.io, log in to the docker registry:
 
     ```
     docker login -u DOCKER-USERNAME -p DOCKER-PASSWORD registry.pivotal.io
     ```
-4. Create a Kubernetes secret for accessing registry containing the <%= vars.product_short %> images by running:
+4. Create a Kubernetes secret for accessing registry containing the Tanzu MySQL images by running:
 
     ```
     kubectl create secret docker-registry tanzu-image-registry --docker-server=https://registry.pivotal.io/ \
@@ -206,7 +190,7 @@ other than registry.pivotal.io, log in to the docker registry:
     ```
     helm chart export REGISTRY-URL
     ```
-    Where `REGISTRY-URL` is the reference to the <%= vars.product_short %> Helm chart.
+    Where `REGISTRY-URL` is the reference to the Tanzu MySQL Helm chart.
 
     <br>The value of `REGISTRY-URL` has the following pattern:
 
@@ -216,7 +200,7 @@ other than registry.pivotal.io, log in to the docker registry:
     Where `VERSION-NUMBER-TAG` is the version of the Helm chart.
 
     <br>This downloads a directory named `tanzu-sql-with-mysql-operator/` into your current working directory that contains:
-    * The <%= vars.product_short %> Helm chart
+    * The Tanzu MySQL Helm chart
     * Custom Resource Definitions (CRDs)
     * Role-Based Access Control (RBAC) definitions required to install the operator with Helm
 
@@ -285,7 +269,7 @@ Confirm and configure the Tanzu SQL operator for your environment:
         <tr>
           <td><code>operatorImage</code></td>
           <td>URI</td>
-          <td>Reference to the <%= vars.product_short %> operator image.
+          <td>Reference to the Tanzu MySQL operator image.
             If you uploaded the operator image to a private registry, you must
             change this reference to pull the operator image from your registry.</td>
         </tr>
@@ -297,12 +281,12 @@ Confirm and configure the Tanzu SQL operator for your environment:
         <tr>
           <td><code>defaultInstanceVersion</code></td>
           <td>String</td>
-          <td>The default version of <%= vars.product_short %> to use when creating new instances.</td>
+          <td>The default version of Tanzu MySQL to use when creating new instances.</td>
         </tr>
         <tr>
           <td><code>resources</code></td>
           <td>List</td>
-          <td>Limits and requests for CPU and memory for the <%= vars.product_short %> operator.
+          <td>Limits and requests for CPU and memory for the Tanzu MySQL operator.
             You can change these values to scale your resources.</td>
         </tr>
       </tbody>
@@ -321,7 +305,7 @@ To install the operator using the Helm CLI:
 1. Verify that you are in the same working directory as where you downloaded the Helm chart in Step 4 of
 [Create Namespace and Secret](#create-namespace-secret) above.
 
-1. Install the <%= vars.product_short %> operator by running one of the following:
+1. Install the Tanzu MySQL operator by running one of the following:
     + If you created a custom `values-override.yaml` in [Review values.yaml and
     Create Overrides If Needed](#create-overrides) above,
     then run the following helm command:
@@ -340,8 +324,8 @@ To install the operator using the Helm CLI:
     ```
     kubectl get all
     ```
-    The <%= vars.product_short %> operator has finished installing when you see the value of the `STATUS` column for the
-    <%= vars.product_short %> operator Pod is `Running`. See example output:
+    The Tanzu MySQL operator has finished installing when you see the value of the `STATUS` column for the
+    Tanzu MySQL operator Pod is `Running`. See example output:
     <pre class="terminal">$ kubectl get all
 NAME                                                           READY   STATUS    RESTARTS   AGE
 pod/mysql-for-kubernetes-controller-manager-84d76dfb77-lq5mb   1/1     <span style="color: #77bf00;">Running</span>   0          21s
@@ -351,5 +335,269 @@ deployment.apps/mysql-for-kubernetes-controller-manager   1/1     1            1
 replicaset.apps/mysql-for-kubernetes-controller-manager-84d76dfb77   1         1         1       23s</pre>
 
     <p class="note">
-      <strong>Note:</strong> You can only have one <%= vars.product_short %> operator installed in a Kubernetes cluster.
+      <strong>Note:</strong> You can only have one Tanzu MySQL operator installed in a Kubernetes cluster.
     </p>
+
+## <a id="install-via-tar"></a>Install Tanzu Operator via a Downloaded Archive File
+        
+Choose this method if:
+
+- The installation destination (for example an air-gapped network) cannot access the [VMware Tanzu Network](https://network.pivotal.io).
+- Or you wish to load the Operator and instance images to private Docker registry.
+
+This section covers:
+
+- Downloading and unpacking the <%=vars.product_full %> distribution from [VMware Tanzu Network](https://network.pivotal.io)
+- Loading the images to a local Docker registry
+- Pushing the images from the local Docker registry to a private container registry
+- Configuring a Kubernetes secret for accessing the private container registry
+- Deploying the MySQL operator
+
+### <a id="download-prerequisites"></a>Prerequisites
+
+Before you deploy the <%=vars.product_full %> Operator, review the list of [Prerequisites](#prereq) that apply to both installation methods. 
+
+### Download and unpack the <%=vars.product_full %> distribution 
+
+1. Download the <%=vars.product_full %> distribution from [VMware Tanzu Network](https://network.pivotal.io). The <%=vars.product_full %> download filename has the format: `tanzu-mysql-for-kubernetes-<version>.tgz`
+
+2. Unpack the downloaded software:
+
+    ``` bash
+    $ cd ~/Downloads
+    $ tar xzf tanzu-mysql-for-kubernetes-<version>.tgz
+    ```
+
+    This command unpacks the distribution into a new directory named `tanzu-mysql-for-kubernetes-<version>`, for example `tanzu-mysql-for-kubernetes-1.1.0`.
+
+3.  Change to the new `tanzu-mysql-for-kubernetes-<version>` directory.
+
+    ``` bash
+    $ cd ./tanzu-mysql-for-kubernetes-*
+    ```
+
+### <a id="docker"></a>Load the Images to a Local Docker Registry
+
+1. Load the MySQL instance image to the Docker registry.
+
+    ``` bash
+    $ docker load -i ./images/tanzu-mysql-instance
+    ```
+
+2.  Load the MySQL operator image to the Docker registry.
+
+    ``` bash
+    $ docker load -i ./images/tanzu-mysql-operator
+    ```
+
+3.  Verify that the two Docker images are now available.
+
+    ``` bash
+    $ docker images "tanzu-mysql-*"
+    ```
+
+### <a id="push-to-registry"></a>Push the Images from the local Docker Registry to a Private Container Registry
+
+Push the <%= vars.product_full %> Docker images to the container registry of your choice. Set each image's project and image repo name, tag the images, and then push them using the Docker command `docker push`.
+
+This example tags and pushes the images to the Google Cloud Registry, using the default (core) project name for the example Google Cloud account.
+
+``` bash
+$ gcloud auth configure-docker
+
+$ PROJECT=$(gcloud config list core/project --format='value(core.project)')
+$ REGISTRY="gcr.io/${PROJECT}"
+
+$ INSTANCE_IMAGE_NAME="${REGISTRY}/tanzu-mysql-instance:$(cat ./images/tanzu-mysql-instance-tag)"
+$ docker tag $(cat ./images/tanzu-mysql-instance-id) ${INSTANCE_IMAGE_NAME}
+$ docker push ${INSTANCE_IMAGE_NAME}
+
+$ OPERATOR_IMAGE_NAME="${REGISTRY}/tanzu-mysql-operator:$(cat ./images/tanzu-mysql-operator-tag)"
+$ docker tag $(cat ./images/tanzu-mysql-operator-id) ${OPERATOR_IMAGE_NAME}
+$ docker push ${OPERATOR_IMAGE_NAME}
+```
+
+### <a id="create-service-accounts"></a>Configure a Kubernetes Secret for Accessing the Private Container Registry
+
+Create a `docker-registry` type secret to allow the Kubernetes cluster to authenticate with the private container registry so it can pull images. These examples create a secret named `regsecret` using Harbor, Google Cloud Registry (GCR), and Amazon Elastic Container Registry (ECR). 
+
+**IMPORTANT**: The commands below create the secret in the `default` namespace. Only pods created in the same `default` namespace can reference the secret. To create a secret in a different namespace, use the `--namespace` flag.
+
+**Harbor**
+
+``` bash
+$ kubectl create secret docker-registry regsecret \
+    --docker-server=${HARBOR_URL} \
+    --docker-username=${HARBOR_USER} \
+    --docker-password="${HARBOR_PASSWORD}"
+```
+
+**GCR**
+
+``` bash
+$ kubectl create secret  docker-registry  regsecret \
+        --docker-server=https://gcr.io \
+        --docker-username=_json_key \
+        --docker-password="$(cat ~/key.json)"
+```
+For information about how to obtain the `key.json` service account file, see [Kubernetes Service Account](prepare-gke.html#key-file)
+
+**ECR**
+
+``` bash
+$ TOKEN=`aws ecr --region=$REGION get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`
+$ kubectl create secret docker-registry regsecret \
+    --docker-server=https://${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com \
+    --docker-username=AWS \
+    --docker-password="${TOKEN}"
+```
+
+
+Next follow [Deploying a MySQL Operator](install-operator.html#create-operator). The MySQL operator will use this secret to allow the Kubernetes cluster to authenticate with the container registry to pull images.
+
+### <a id="create-operator"></a> Deploy the MySQL Operator 
+
+The MySQL operator is the controller for MySQL instances resources. You install the MySQL operator using the Helm package manager.
+
+#### <a id="config-file"></a>Edit the Operator Configuration
+
+1.  Go to the directory where you unpacked the <%=vars.product_full %> distribution.
+
+    ``` bash
+    $ cd tanzu-mysql-for-kubernetes-*
+    ```
+    The file `charts/tanzu-sql-with-mysql-operator/values.yaml` in the <%= vars.product_full %> directory specifies the location of the MySQL operator and instance images. By default it contains the following values:
+    
+    ```
+---
+imagePullSecretName: tanzu-image-registry
+operatorImage: registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.1.0-rc.8
+registry: "registry.pivotal.io/tanzu-mysql-for-kubernetes/"
+defaultInstanceVersion: 1.1.0-rc.8
+resources: {}
+    ```
+
+3. .
+
+1.  Create a copy of `values.yaml` and name the new file `operator-values-overrides.yaml`. Save this file in the same directory as the `values.yaml` file. In this file, you can specify the custom container registry and secret. For manual changes, you may also set individual parameters using the `--set` flag on the command line. 
+
+    See [Helm Values Files](https://helm.sh/docs/chart_template_guide/values_files/) in the Helm documentation for more information.<br><br>
+
+    If you are using a single node Minikube environment, it is not necessary to override the `operator/values.yaml` file because Minikube pulls the images from its local Docker registry.
+    <br><br>
+    Determine which values in the `values.yaml` file need to be changed for your environment. Use the table below as a guide.
+    <table>
+      <thead>
+        <tr>
+          <th width="30%">Key</th>
+          <th width="15%">Value Type</th>
+          <th width="55%">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>imagePullSecret</code></td>
+          <td>String</td>
+          <td>Name of image secret. This value must match the name of the Kubernetes
+            secret you create in <a href="#create-namespace-secret">Create Namespace and Secret</a> above.</td>
+        </tr>
+        <tr>
+          <td><code>operatorImage</code></td>
+          <td>URI</td>
+          <td>Reference to the Tanzu MySQL operator image.
+            If you uploaded the operator image to a private registry, you must
+            change this reference to pull the operator image from your registry.</td>
+        </tr>
+        <tr>
+          <td><code>registry</code></td>
+          <td>URI</td>
+          <td>The registry from which to download Tanzu MySQL images.</td>
+        </tr>
+        <tr>
+          <td><code>defaultInstanceVersion</code></td>
+          <td>String</td>
+          <td>The default version of Tanzu MySQL to use when creating new instances.</td>
+        </tr>
+        <tr>
+          <td><code>resources</code></td>
+          <td>List</td>
+          <td>Limits and requests for CPU and memory for the Tanzu MySQL operator.
+            You can change these values to scale your resources.</td>
+        </tr>
+      </tbody>
+    </table>
+
+1. Edit the values that you want to change.
+1. Delete the sections of the file that you do not change.
+1.  Save the `operator-values-overrides.yaml` file in a location of your choice or the same directory as the `values.yaml` file.
+
+#### <a id="create-release"></a>Create the MySQL Operator 
+    
+1.  Use Helm to install the MySQL operator in your Kubernetes cluster.
+
+    ``` bash
+    $ helm install --wait my-mysql-operator operator/
+    ```
+
+    where:
+    * `--wait` flag waits for the Operator deployment to complete before any image installation starts
+    * `my-mysql-operator` is the custom name you provide for your MySQL operator
+    * `operator/` is the location of the MySQL Operator helm chart 
+
+    or
+
+    ``` bash
+    $ helm install --wait my-mysql-operator -f charts/tanzu-sql-with-mysql-operator/operator-values-overrides.yaml charts/tanzu-sql-with-mysql-operator/
+    ```
+    
+    Replace `charts/tanzu-sql-with-mysql-operator/operator-values-overrides.yaml` with your custom location.
+    <br><br>
+
+    To create the Operator in a namespace different that the default, use:
+    
+    ``` bash
+    $ helm install --wait my-mysql-operator charts/tanzu-sql-with-mysql-operator/ \
+      --namespace=${OPERATOR_NAMESPACE} \
+      --create-namespace \   
+    ```
+
+    Helm installs the new release into the Kubernetes namespace specified in the current Kubernetes context. The command displays a message similar to:
+
+    ```
+    NAME: my-mysql-operator
+    LAST DEPLOYED: Wed Jun 16 13:28:05 2021
+    NAMESPACE: default
+    STATUS: deployed
+    REVISION: 1
+    TEST SUITE: None
+    ```
+    
+    **Note**: The secret namespace in step [Create a Kubernetes Access Secret](#create-service-accounts) must match the Operator namespace.  
+
+3.  Use `watch kubectl get all` to monitor the progress of the deployment. The deployment is complete when the MySQL Operator pod status changes to `Running`.
+
+    ``` bash
+    $ watch kubectl get all
+    ```
+    
+    You may also check the logs to confirm the Operator is running properly:
+
+    ``` bash
+    $ kubectl logs -l app=mysql-operator
+    ```
+    
+    Use the label `app=mysql-operator` to search across resources created by the MySQL Operator Helm chart:
+
+    ``` bash
+    $ kubectl get all -l app=mysql-operator -n mysql-operator
+    ```
+    where `-n mysql-operator` defines the namespace. The output would be similar to:
+
+    ``` bash
+    NAME                                           READY       STATUS           RESTARTS      AGE
+    pod/mysql-operator-69765b8b74-rtms7            1/1         Running          0             3d19h
+    NAME                                           READY       UP-TO-DATE       AVAILABLE     AGE
+    deployment.apps/mysql-operator                 1/1         1                1             3d19h
+    NAME                                           DESIRED     CURRENT          READY         AGE
+    replicaset.apps/mysql-operator-69765b8b74      1           1                1             3d19h
+    ```

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -14,8 +14,10 @@ This topic describes how to install <%= vars.product_full %> using two different
 ## <a id="install-via-tanzu"></a>Install Tanzu MySQL Operator via the Tanzu Network Registry
 
 This section describes how to access the resources, and deploy the <%=vars.product_full %> Operator using the Tanzu Network Registry. 
+To install the Tanzu MySQL operator, you must use kubectl to create a namespace and secret.
+Then, use the Helm CLI to install the operator.
 
-### <a id='tanzu-prereq'></a>Prerequisites
+### <a id='tanzu-network-prerequisites'></a>Prerequisites
 
 Before you deploy the Tanzu MySQL operator, you need:
 
@@ -98,67 +100,21 @@ To download the resources:
 
     Follow the prompts to enter the email address and password for your <%= vars.product_network %> account.
 
-1. Log in to [<%= vars.product_network %>](https://network.pivotal.io) and go to
-the **<%= vars.product_full %>** product page.
+1. Download the `tanzu-mysql-operator-chart` using Helm:
 
-1. Click **Artifact References** to navigate into the artifacts directory. Keep the page
-open to reference in the following step.
+    ```
+    $ helm chart pull registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.1.0
+    1.1.0: Pulling from registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart
+    ref:     <span style="color: #77bf00;">registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.1.0</span>
+    digest:  2b6e1d010ab1737dcc5a426b223a06db1c616107d2ceaf368db6fda48d96a61a
+    size:    4.2 KiB
+    name:    tanzu-sql-with-mysql-operator
+    version: 1.1.0
+    Status: Downloaded newer chart for registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.1.0
+    ```
 
-1. Download each of the artifact references using the command line.
-  1. **To download `tanzu-mysql-operator-chart` to the Helm cache:** Click the artifact from <%= vars.product_network %> and paste the
-  two commands into the command line.
-  <br><%= image_tag("tanzu-mysql-operator-artifact.png", :width => "450px",
-  :alt=>"Modal shows 4 pieces of data: type, digest, 'set the environment variable' and 'pull this chart'") %>
-  <br><a href="./images/tanzu-mysql-operator-artifact.png" target="_blank" aria-hidden="true">Click here to view a larger version of this diagram</a>
-  <br><br>For example:
-  <pre class="terminal">$ export HELM\_EXPERIMENTAL\_OCI=1
-$ helm chart pull registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.1.0
-<br>1.1.0: Pulling from registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart
-ref:     <span style="color: #77bf00;">registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.1.0</span>
-digest:  2b6e1d010ab1737dcc5a426b223a06db1c616107d2ceaf368db6fda48d96a61a
-size:    4.2 KiB
-name:    tanzu-sql-with-mysql-operator
-version: 1.1.0
-Status: Downloaded newer chart for registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.1.0</pre>
-  1. **To download `tanzu-mysql-instance`:** Click the artifact from <%= vars.product_network %> and paste the
-  command into the command line.
-  <br><br>For example:
-  <pre class="terminal">$ docker pull registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-instance:1.1.0
-    <br>1.1.0: Pulling from tanzu-mysql-for-kubernetes/tanzu-mysql-instance
-f22ccc0b8772: Pull complete
-3cf8fb62ba5f: Pull complete
-e80c964ece6a: Pull complete
-0c31331fda89: Pull complete
-0e9674cd2c60: Pull complete
-d88e035d5311: Pull complete
-5055f7e93495: Pull complete
-80e0c3183303: Pull complete
-6312f33f1306: Pull complete
-47733910cd21: Pull complete
-4ac582ac7e82: Pull complete
-e9ad4cffabdc: Pull complete
-4b9107ee1e3e: Pull complete
-faffd54990ce: Pull complete
-Digest: sha256:78073dcf626603da192b78643bda24e0098f944d0bd54da1d60924b20d5eea8c
-Status: Downloaded newer image for registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-instance:1.1.0
-registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-instance:1.1.0</pre>
-  1. **To download the `tanzu-mysql-operator` image:** Click the artifact from <%= vars.product_network %> and paste the
-  command into the command line.
-  <br><br>For example:
-  <pre class="terminal">$ docker pull registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.1.0
-    <br>1.1.0: Pulling from tanzu-mysql-for-kubernetes/tanzu-mysql-operator
-be69922ffb42: Pull complete
-ef291e196a72: Pull complete
-Digest: sha256:91664f6866b7228b68d3fb9ff8e13af95f618b7b78e5fd35690dd29394a08db1
-Status: Downloaded newer image for registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.1.0
-registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.1.0</pre>
+### <a id="create-namespace-secret"></a> Create Namespace and Secret
 
-### <a id="install"></a> Install the Operator
-
-To install the Tanzu MySQL operator, you must use kubectl to create a namespace and secret.
-Then, use the Helm CLI to install the operator.
-
-#### <a id="create-namespace-secret"></a> Create Namespace and Secret
 To create the namespace and secret:
 
 1. Create the namespace by running:
@@ -172,13 +128,8 @@ To create the namespace and secret:
     ```
     kubectl config set-context --current --namespace tanzu-mysql-for-kubernetes-system
     ```
-3. If you want to deploy the Tanzu MySQL images from a registry
-other than registry.pivotal.io, log in to the docker registry:
 
-    ```
-    docker login -u DOCKER-USERNAME -p DOCKER-PASSWORD registry.pivotal.io
-    ```
-4. Create a Kubernetes secret for accessing registry containing the Tanzu MySQL images by running:
+1. Create a Kubernetes secret for accessing registry containing the Tanzu MySQL images by running:
 
     ```
     kubectl create secret docker-registry tanzu-image-registry --docker-server=https://registry.pivotal.io/ \
@@ -204,7 +155,7 @@ other than registry.pivotal.io, log in to the docker registry:
     * Custom Resource Definitions (CRDs)
     * Role-Based Access Control (RBAC) definitions required to install the operator with Helm
 
-    <br>For example:
+    For example:
     <pre class="terminal">$ helm chart export registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.1.0
     <br>ref:     registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.1.0
     digest:  2b6e1d010ab1737dcc5a426b223a06db1c616107d2ceaf368db6fda48d96a61a
@@ -214,112 +165,41 @@ other than registry.pivotal.io, log in to the docker registry:
     Exported chart to tanzu-sql-with-mysql-operator/
     </pre>
 
-#### <a id="create-overrides"></a> Review values.yaml and Create Overrides If Needed
+### <a id="create-overrides"></a> Review values.yaml and Create Overrides If Needed
 
-In most situtations, the default values supplied in the `values.yaml` file do not need to be changed.
+In most situations, the default values supplied in the `values.yaml` file do not need to be changed.
 
 However, if any of the following are true, you need to follow the steps below to override the defaults:
 
-+ You deployed the Tanzu SQL for Kubernetes images from a registry other than registry.pivotal.io.
-+ You did not use the default `tanzu-image-registry` for the secret name in Step 4 above.
-+ You want to allocate different CPU or memory resources for your operator.
-+ You want to specify an alternate default version for new MySQL instances.
+* You deployed the Tanzu SQL for Kubernetes images from a registry other than registry.pivotal.io.
+* You did not use the default `tanzu-image-registry` for the secret name in Step 4 above.
+* You want to allocate different CPU or memory resources for your operator.
+* You want to specify an alternate default version for new MySQL instances.
 
-<p class="note">
-<strong>Note:</strong>
-Do not edit <code>values.yaml</code> directly. Create a <code>values-override.yaml</code>.
-</p>
+If you do wish to override default values, follow the steps described in [Edit the Operator Configuration](#config-file).
 
-Confirm and configure the Tanzu SQL operator for your environment:
-
-1. Review the `values.yaml` file.
-
-    For example:
-    <pre><code>---
-    imagePullSecret: tanzu-image-registry
-    <br>operatorImage: registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.1.0
-    <br>registry: "registry.pivotal.io/tanzu-mysql-for-kubernetes/"
-		<br>defaultInstanceVersion: 1.1.0
-    <br>resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi
-    </code></pre>
-
-2. Determine which values in the `values.yaml` file need to be changed for your environment.
-       Use the table below as a guide.
-    <table>
-      <thead>
-        <tr>
-          <th width="30%">Key</th>
-          <th width="15%">Value Type</th>
-          <th width="55%">Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>imagePullSecret</code></td>
-          <td>String</td>
-          <td>Name of image secret. This value must match the name of the Kubernetes
-            secret you create in <a href="#create-namespace-secret">Create Namespace and Secret</a> above.</td>
-        </tr>
-        <tr>
-          <td><code>operatorImage</code></td>
-          <td>URI</td>
-          <td>Reference to the Tanzu MySQL operator image.
-            If you uploaded the operator image to a private registry, you must
-            change this reference to pull the operator image from your registry.</td>
-        </tr>
-        <tr>
-          <td><code>registry</code></td>
-          <td>URI</td>
-          <td>The registry from which to download Tanzu MySQL images.</td>
-        </tr>
-        <tr>
-          <td><code>defaultInstanceVersion</code></td>
-          <td>String</td>
-          <td>The default version of Tanzu MySQL to use when creating new instances.</td>
-        </tr>
-        <tr>
-          <td><code>resources</code></td>
-          <td>List</td>
-          <td>Limits and requests for CPU and memory for the Tanzu MySQL operator.
-            You can change these values to scale your resources.</td>
-        </tr>
-      </tbody>
-    </table>
-
-3. Create a copy of `values.yaml` and name the new file`values-override.yaml`.
-
-4. Edit the values that you want to change.
-5. Delete the sections of the file that you do not change.
-6. Save the `values-override.yaml` file in the same directory as the `values.yaml` file.
-
-#### <a id="install-operator"></a> Use Helm CLI to Install the Operator
+### <a id="install-operator"></a> Use Helm CLI to Install the Operator
 
 To install the operator using the Helm CLI:
 
 1. Verify that you are in the same working directory as where you downloaded the Helm chart in Step 4 of
 [Create Namespace and Secret](#create-namespace-secret) above.
 
-1. Install the Tanzu MySQL operator by running one of the following:
-    + If you created a custom `values-override.yaml` in [Review values.yaml and
-    Create Overrides If Needed](#create-overrides) above,
-    then run the following helm command:
+1. Install the Tanzu MySQL operator.
 
-        ```
-        helm install --values=/your/values-override.yaml tanzu-sql-with-mysql-operator ./tanzu-sql-with-mysql-operator/
-        ```
-    + If you did not create a `values-override.yaml`, then run the following helm command:
+    If you created a custom `values-override.yaml` in [Review values.yaml and Create Overrides If Needed](#create-overrides) above, then run the following Helm command, including the `--values` flag with the location of your override file:
 
-        ```
-        helm install tanzu-sql-with-mysql-operator ./tanzu-sql-with-mysql-operator/
-        ```
+    ```
+    helm install --values=/your/values-override.yaml tanzu-sql-with-mysql-operator ./tanzu-sql-with-mysql-operator/
+    ```
 
-1. See that your operator has installed successfully by running:
+    Otherwise, omit the `--values` flag:
+
+    ```
+    helm install tanzu-sql-with-mysql-operator ./tanzu-sql-with-mysql-operator/
+    ```
+
+1. See that the operator has installed successfully by running:
 
     ```
     kubectl get all
@@ -343,7 +223,7 @@ replicaset.apps/mysql-for-kubernetes-controller-manager-84d76dfb77   1         1
 Choose this method if:
 
 - The installation destination (for example an air-gapped network) cannot access the [VMware Tanzu Network](https://network.pivotal.io).
-- Or you wish to load the Operator and instance images to private Docker registry.
+- Or you wish to load the Operator and instance images to a private Docker registry.
 
 This section covers:
 
@@ -353,7 +233,7 @@ This section covers:
 - Configuring a Kubernetes secret for accessing the private container registry
 - Deploying the MySQL operator
 
-### <a id="download-prerequisites"></a>Prerequisites
+### <a id="download-archive-prerequisites"></a>Prerequisites
 
 Before you deploy the <%=vars.product_full %> Operator, review the list of [Prerequisites](#prereq) that apply to both installation methods. 
 
@@ -373,7 +253,7 @@ Before you deploy the <%=vars.product_full %> Operator, review the list of [Prer
 3.  Change to the new `tanzu-mysql-for-kubernetes-<version>` directory.
 
     ``` bash
-    $ cd ./tanzu-mysql-for-kubernetes-*
+    $ cd ./tanzu-mysql-for-kubernetes-1.1.0
     ```
 
 ### <a id="docker"></a>Load the Images to a Local Docker Registry
@@ -393,7 +273,10 @@ Before you deploy the <%=vars.product_full %> Operator, review the list of [Prer
 3.  Verify that the two Docker images are now available.
 
     ``` bash
-    $ docker images "tanzu-mysql-*"
+$ docker images
+REPOSITORY                                                            TAG       IMAGE ID       CREATED        SIZE
+registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-instance   1.1.0     5f0ad7bad51b   5 weeks ago    792MB
+registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator   1.1.0     eb1458d2e1bd   5 weeks ago    76MB
     ```
 
 ### <a id="push-to-registry"></a>Push the Images from the local Docker Registry to a Private Container Registry
@@ -419,14 +302,14 @@ $ docker push ${OPERATOR_IMAGE_NAME}
 
 ### <a id="create-service-accounts"></a>Configure a Kubernetes Secret for Accessing the Private Container Registry
 
-Create a `docker-registry` type secret to allow the Kubernetes cluster to authenticate with the private container registry so it can pull images. These examples create a secret named `regsecret` using Harbor, Google Cloud Registry (GCR), and Amazon Elastic Container Registry (ECR). 
+Create a `docker-registry` type secret to allow the Kubernetes cluster to authenticate with the private container registry so it can pull images. These examples create a secret named `tanzu-image-registry` using Harbor, Google Cloud Registry (GCR), and Amazon Elastic Container Registry (ECR). 
 
 **IMPORTANT**: The commands below create the secret in the `default` namespace. Only pods created in the same `default` namespace can reference the secret. To create a secret in a different namespace, use the `--namespace` flag.
 
 **Harbor**
 
 ``` bash
-$ kubectl create secret docker-registry regsecret \
+$ kubectl create secret docker-registry tanzu-image-registry \
     --docker-server=${HARBOR_URL} \
     --docker-username=${HARBOR_USER} \
     --docker-password="${HARBOR_PASSWORD}"
@@ -435,7 +318,7 @@ $ kubectl create secret docker-registry regsecret \
 **GCR**
 
 ``` bash
-$ kubectl create secret  docker-registry  regsecret \
+$ kubectl create secret  docker-registry  tanzu-image-registry \
         --docker-server=https://gcr.io \
         --docker-username=_json_key \
         --docker-password="$(cat ~/key.json)"
@@ -446,7 +329,7 @@ For information about how to obtain the `key.json` service account file, see [Ku
 
 ``` bash
 $ TOKEN=`aws ecr --region=$REGION get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`
-$ kubectl create secret docker-registry regsecret \
+$ kubectl create secret docker-registry tanzu-image-registry \
     --docker-server=https://${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com \
     --docker-username=AWS \
     --docker-password="${TOKEN}"
@@ -581,21 +464,21 @@ resources: {}
     You may also check the logs to confirm the Operator is running properly:
 
     ``` bash
-    $ kubectl logs -l app=mysql-operator
+    $ kubectl logs -l app=tanzu-mysql-operator
     ```
     
-    Use the label `app=mysql-operator` to search across resources created by the MySQL Operator Helm chart:
+    Use the label `app=tanzu-mysql-operator` to search across resources created by the MySQL Operator Helm chart:
 
     ``` bash
-    $ kubectl get all -l app=mysql-operator -n mysql-operator
+    $ kubectl get all -l app=tanzu-mysql-operator -n mysql-operator
     ```
     where `-n mysql-operator` defines the namespace. The output would be similar to:
 
     ``` bash
     NAME                                           READY       STATUS           RESTARTS      AGE
-    pod/mysql-operator-69765b8b74-rtms7            1/1         Running          0             3d19h
+    pod/tanzu-mysql-operator-69765b8b74-rtms7            1/1         Running          0             3d19h
     NAME                                           READY       UP-TO-DATE       AVAILABLE     AGE
-    deployment.apps/mysql-operator                 1/1         1                1             3d19h
+    deployment.apps/tanzu-mysql-operator                 1/1         1                1             3d19h
     NAME                                           DESIRED     CURRENT          READY         AGE
-    replicaset.apps/mysql-operator-69765b8b74      1           1                1             3d19h
+    replicaset.apps/tanzu-mysql-operator-69765b8b74      1           1                1             3d19h
     ```

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -474,9 +474,9 @@ resources: {}
     Use the label `app=tanzu-mysql-operator` to search across resources created by the MySQL Operator Helm chart:
 
     ``` bash
-    $ kubectl get all -l app=tanzu-mysql-operator -n mysql-operator
+    $ kubectl get all -l app=tanzu-mysql-operator -n mysql-for-kubernetes-system
     ```
-    where `-n mysql-operator` defines the namespace. The output would be similar to:
+    where `-n mysql-for-kubernetes-system` defines the namespace. The output would be similar to:
 
     ``` bash
     NAME                                           READY       STATUS           RESTARTS      AGE

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -75,7 +75,7 @@ Before you deploy the Tanzu MySQL operator, you need:
     
     For more advanced security scenarios, see [Configuring TLS for MySQL Instances](configure-tls.html). 
 
-## <a id="access"></a> Access the Resources
+### <a id="access"></a> Access the Resources
 
 To install the Tanzu MySQL operator, you must download the Helm chart and images.
 
@@ -158,7 +158,7 @@ registry.pivotal.io/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.1.0</pre>
 To install the Tanzu MySQL operator, you must use kubectl to create a namespace and secret.
 Then, use the Helm CLI to install the operator.
 
-### <a id="create-namespace-secret"></a> Create Namespace and Secret
+#### <a id="create-namespace-secret"></a> Create Namespace and Secret
 To create the namespace and secret:
 
 1. Create the namespace by running:
@@ -214,7 +214,7 @@ other than registry.pivotal.io, log in to the docker registry:
     Exported chart to tanzu-sql-with-mysql-operator/
     </pre>
 
-### <a id="create-overrides"></a> Review values.yaml and Create Overrides If Needed
+#### <a id="create-overrides"></a> Review values.yaml and Create Overrides If Needed
 
 In most situtations, the default values supplied in the `values.yaml` file do not need to be changed.
 
@@ -298,7 +298,7 @@ Confirm and configure the Tanzu SQL operator for your environment:
 5. Delete the sections of the file that you do not change.
 6. Save the `values-override.yaml` file in the same directory as the `values.yaml` file.
 
-### <a id="install-operator"></a> Use Helm CLI to Install the Operator
+#### <a id="install-operator"></a> Use Helm CLI to Install the Operator
 
 To install the operator using the Helm CLI:
 
@@ -476,8 +476,6 @@ registry: "registry.pivotal.io/tanzu-mysql-for-kubernetes/"
 defaultInstanceVersion: 1.1.0-rc.8
 resources: {}
     ```
-
-3. .
 
 1.  Create a copy of `values.yaml` and name the new file `operator-values-overrides.yaml`. Save this file in the same directory as the `values.yaml` file. In this file, you can specify the custom container registry and secret. For manual changes, you may also set individual parameters using the `--set` flag on the command line. 
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -57,7 +57,7 @@ The <%= vars.product_short %> releases support the components listed below:
 - `instanceImage` has been deprecated and removed from the <%= vars.product_short %> Helm chart. This release introduces two new chart values, `registry` and `defaultInstanceVersion`. Users should specify `registry: <my.private-registry>` in their `values-override.yaml`. For more details, see [Installing the Tanzu SQL for Kubernetes Operator](./install-operator.html).
 - `imagePullSecret` has been renamed to `imagePullSecretName` for the Helm chart and the MySQL resource, and it's now optional. Users who are maintaining a deployment file for the object should rename the field or drop the field entirely. If omitted, the `imagePullSecretName` will default to the Helm chart setting.
 - Users can now alter `spec.storageSize` in a MySQL object to scale up the PV (Persistent Volume), if the underlying storage class supports `onlineVolumeExpansion`. See [Scale storageSize](./update-instance.html#scale-storage). 
-- Before installing the Tanzu MySQL operator, this release now requires cert-manager installation. For details, see [Installing the Tanzu SQL for Kubernetes Operator](./install-operator.html).
+- Before installing the Tanzu MySQL operator, this release now requires cert-manager installation. For details, see [Prerequisites for Installing via the Tanzu Network Registry](./install-operator.html#tanzu-network-prerequisites).
 
 ### <a id="11_resolved"></a>Resolved Issues
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -40,7 +40,7 @@ The <%= vars.product_short %> releases support the components listed below:
 * Release 1.1.0 supports Percona XtraBackup 8.0.25. For details on Percona XtraBackup 8.0.25 see [Percona XtraBackup Release Notes](https://www.percona.com/doc/percona-xtrabackup/LATEST/release-notes/8.0/8.0.25-17.0.html).
 * Tanzu MySQL instances are now created with a version number. Users may specify the `spec.version` field in the instance definition to specify which Tanzu MySQL version to deploy. Users can now list instances by version number. For more details, see [List Instances By Version](upgrade-instance.html).
 * When installing <%= vars.product_full %>, users can specify a default version for new Tanzu MySQL instances. For more details, see [Installing the Operator](./install-operator.html).
-* <%= vars.product_short %> now requires installing Cert Manager before creating or updating new instances. For more details, see [Prerequisites](install-operator.html#prereq).
+* <%= vars.product_short %> now requires installing Cert Manager before creating or updating new instances. For more details, see [Installing the Operator](./install-operator.html).
 * <%= vars.product_short %> instances now expose Prometheus compatible metrics endpoints. Metrics are secured behind a self-signed TLS certificate. For more details see [Monitoring MySQL Instances in Kubernetes](monitoring.html).
 * This release supports an additional auto-recovery feature: an HA cluster that loses quorum can now recover its state. 
 * Customers can now upgrade from a previous release to a new release. For more information on the process, see [Upgrading MySQL Instances](upgrade-instance.html).
@@ -54,10 +54,10 @@ The <%= vars.product_short %> releases support the components listed below:
 ### <a id="11_changes"></a>Changes
 
 
-- `instanceImage` has been deprecated and removed from the <%= vars.product_short %> Helm chart. This release introduces two new chart values, `registry` and `defaultInstanceVersion`. Users should specify `registry: <my.private-registry>` in their `values-override.yaml`. For more details, see [Installing the Tanzu SQL for Kubernetes Operator](install-operator.html).
+- `instanceImage` has been deprecated and removed from the <%= vars.product_short %> Helm chart. This release introduces two new chart values, `registry` and `defaultInstanceVersion`. Users should specify `registry: <my.private-registry>` in their `values-override.yaml`. For more details, see [Installing the Tanzu SQL for Kubernetes Operator](./install-operator.html).
 - `imagePullSecret` has been renamed to `imagePullSecretName` for the Helm chart and the MySQL resource, and it's now optional. Users who are maintaining a deployment file for the object should rename the field or drop the field entirely. If omitted, the `imagePullSecretName` will default to the Helm chart setting.
 - Users can now alter `spec.storageSize` in a MySQL object to scale up the PV (Persistent Volume), if the underlying storage class supports `onlineVolumeExpansion`. See [Scale storageSize](./update-instance.html#scale-storage). 
-- Before installing the Tanzu MySQL operator, this release now requires cert-manager installation. For details, see [Installing the Tanzu SQL for Kubernetes Operator - Prerequisites](install-operator.html#prereq).
+- Before installing the Tanzu MySQL operator, this release now requires cert-manager installation. For details, see [Installing the Tanzu SQL for Kubernetes Operator](./install-operator.html).
 
 ### <a id="11_resolved"></a>Resolved Issues
 
@@ -107,7 +107,7 @@ For an overview of this product, see [About <%= vars.product_short %>](index.htm
 * **Installation Using Helm:** Kubernetes admins can use Helm to install the <%= vars.product_short %> Operator.
   This simplifies the installation process while maintaining flexibility in configuration.
   For information about how to install the <%= vars.product_short %> Operator,
-  see [Installing the Operator](install-operator.html).
+  see [Installing the Operator](./install-operator.html).
 
 * **Backup and Restore:** <%= vars.product_short %> automates on-demand and scheduled full physical backups
   using the [Percona XtraBackup](https://www.percona.com/software/mysql-database/percona-xtrabackup) tool.


### PR DESCRIPTION
The updated page can be viewed at https://mysql-k8s-install-archive.sc2-04-pcf1-apps.oc.vmware.com/tanzu-mysql-kubernetes/1-1/install-operator.html