### PR TITLE
Feature/ha affinity tolerances

### DIFF
--- a/property-reference-mysql-2.html.md.erb
+++ b/property-reference-mysql-2.html.md.erb
@@ -397,7 +397,7 @@ resources:
 **`resources.proxy: <requests.cpu, requests.memory>`**<br />
 **Optional**<br />
 **Default**: Best effort<br />
-The minimum CPU and memory allowed for the MySQL proxy container that handles connections to MySQL when `highAvailability.enabled` is true. If not specified, defaults to limits, if limits have been explicitly specified. For more information see [Manage Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) in the Kubernetes documentation.<br />
+The minimum CPU and memory allowed for the MySQL proxy container that handles connections to MySQL when `highAvailability.enabled` is true. If not specified, defaults to limits, if limits have been explicitly specified. For more information about limits, see theFor more information about managing resources for containers, see [Manage Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) in the Kubernetes documentation.<br />
 **Example**: 
 
 ```

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -2,7 +2,7 @@
 title: Tanzu MySQL CRD Property Reference
 ---
 
-This topic describes the available fields of the Tanzu MysQL Custom Resource Definition. 
+This topic describes the available fields of the Tanzu MySQL Custom Resource Definition. 
 
 ## <a id="synopsis"></a>Synopsis
 
@@ -158,6 +158,12 @@ The StorageClass used for PVCs associated with MySQL instance Pods. Cannot be mo
 **Default**: ClusterIP<br />
 The type of Service used to provide access to the MySQL database. Only `ClusterIP` and `LoadBalancer` are supported. For more information about Kubernetes ServiceTypes, see the [Service Types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) in the Kubernetes documentation.<br />
 **Example**: LoadBalancer
+
+**`version: <string>`**<br />
+**Optional**<br />
+**Default**: The value of <code>defaultInstanceVersion</code> set by the service administrator in the Tanzu MySQL Helm chart. <br />
+The version of the MySQL instance installed. Can be any of '1.0.0', '1.1.0', or '1.2.0'.<br />
+**Example**: 1.1.0
 
 **`tls.secret.name: <string>`**<br />
 **Optional**<br />

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -205,7 +205,7 @@ spec:
 **`databasePodConfig.tolerations: <corev1.Toleration>`**<br />
 **Optional**<br />
 **Default**: No default tolerations are configured by the Tanzu MySQL Operator.<br />
-Configures Kubernetes Tolerations for the MySQL instance's database Pods. The Tolerations can be updated, and are not required when creating resources. For more details on the Kubernetes tolerations concept, see [Taint and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) in the Kubernetes documentation. <br />
+Configures Kubernetes Tolerations for the MySQL instance's database Pods. The Tolerations can be updated, and are not required when creating resources. For more details on the Kubernetes Taints and Tolerations concept, see [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) in the Kubernetes documentation. <br />
 **Example**:
 
 ```
@@ -259,7 +259,7 @@ spec:
 **`proxyPodConfig.tolerations: <corev1.Toleration>`**<br />
 **Optional**<br />
 **Default**: No default tolerations are configured by the Tanzu MySQL Operator<br />
-Configures Kubernetes Tolerations for the MySQL instance's database Pods. For more details on the Kubernetes tolerations concept, see [Taint and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) in the Kubernetes documentation. <br />
+Configures Kubernetes Tolerations for the MySQL instance's database Pods. For more details on the Kubernetes Taints and Tolerations concept, see [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) in the Kubernetes documentation. <br />
 **Example**:
 
 ```

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -329,4 +329,140 @@ The table below explains the properties that you can set in your MySQL resource.
   </td>
   <td>Delete</td>
 </tr>
+<tr>
+  <td><code>spec.databasePodConfig.affinity</code></td>
+  <td>Affinity rules for the MySQL database pods
+    <br /><br />
+    For more information, see the <a href="https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity">Kubernetes documentation</a>.
+    <br /><br />
+    <strong>Type:</strong> Kubernetes Pod Affinity<br />
+    <strong>Optional</strong><br />
+    <strong>Default:</strong>Prefer that database pods for a given instance are scheduled for unique Kubernetes Nodes
+  </td>
+  <td>
+      <code>
+        ---
+        apiVersion: with.sql.tanzu.vmware.com/v1
+        kind: MySQL
+        metadata:
+           name: my-instance
+        spec:
+           storageSize: 1Gi
+           databasePodConfig:
+             affinity:
+               podAntiAffinity:
+                 requiredDuringSchedulingIgnoredDuringExecution:
+                   - weight: 1
+                     podAffinityTerm:
+                       topologyKey: "kubernetes.io/hostname"
+                       labelSelector:
+                         matchExpressions:
+                           - key: "app.kubernetes.io/component"
+                             operator: In
+                             values:
+                               - database
+                           - key: "app.kubernetes.io/instance"
+                             operator: In
+                             values:
+                               - my-instance
+      </code>
+  </td>
+</tr>
+<tr>
+  <td><code>spec.databasePodConfig.tolerations</code></td>
+  <td>Configures Kubernetes Tolerations for the MySQL instance's database Pods
+    <br /><br />
+    For more information, see the <a href="https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/">Kubernetes documentation</a>.
+    <br /><br />
+    <strong>Type:</strong> Kubernetes Pod Tolerations<br />
+    <strong>Optional</strong><br />
+    <strong>Default:</strong>No default tolerations are configured by the Tanzu MySQL Operator
+  </td>
+  <td>
+    <code>
+    ---
+    apiVersion: with.sql.tanzu.vmware.com/v1
+    kind: MySQL
+    metadata:
+       name: my-instance
+    spec:
+       storageSize: 1Gi
+       databasePodConfig:
+         tolerations:
+         - key: node.kubernetes.io/memory-pressure
+           operator: "Exists"
+           effect: "NoExecute"
+           tolerationSeconds: 3600
+    </code>
+  </td>
+</tr>
+<tr>
+  <td><code>spec.proxyPodConfig.affinity</code></td>
+  <td>Affinity rules for the Proxy database pods
+    <br /><br />
+    <b>Used only when spec.highAvailability.enabled = true</b>
+    For more information, see the <a href="https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity">Kubernetes documentation</a>.
+    <br /><br />
+    <strong>Type:</strong> Kubernetes Affinity configuration<br />
+    <strong>Optional</strong><br />
+    <strong>Default:</strong>Prefer that proxy pods are not scheduled on the same Kubernetes node.
+  </td>
+  <td>
+      <code>
+        ---
+        apiVersion: with.sql.tanzu.vmware.com/v1
+        kind: MySQL
+        metadata:
+           name: my-instance
+        spec:
+           storageSize: 1Gi
+           proxyPodConfig:
+             affinity:
+               podAntiAffinity:
+                 requiredDuringSchedulingIgnoredDuringExecution:
+                   - weight: 1
+                     podAffinityTerm:
+                       topologyKey: "kubernetes.io/hostname"
+                       labelSelector:
+                         matchExpressions:
+                           - key: "app.kubernetes.io/component"
+                             operator: In
+                             values:
+                               - proxy
+                           - key: "app.kubernetes.io/instance"
+                             operator: In
+                             values:
+                               - my-instance
+      </code>
+  </td>
+</tr>
+<tr>
+  <td><code>spec.proxyPodConfig.tolerations</code></td>
+  <td>Configures Kubernetes Tolerations for the MySQL instance's proxy Pods
+    <br /><br />
+    <b>Used only when spec.highAvailability.enabled = true</b>
+    For more information, see the <a href="https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/">Kubernetes documentation</a>.
+    <br /><br />
+    <strong>Type:</strong>Kubernetes Tolerations configuration<br />
+    <strong>Optional</strong><br />
+    <strong>Default:</strong>No default tolerations are configured by the Tanzu MySQL Operator
+  </td>
+  <td>
+    <code>
+    ---
+    apiVersion: with.sql.tanzu.vmware.com/v1
+    kind: MySQL
+    metadata:
+       name: my-instance
+    spec:
+       storageSize: 1Gi
+       proxyPodConfig:
+         tolerations:
+         - key: node.kubernetes.io/memory-pressure
+           operator: "Exists"
+           effect: "NoExecute"
+           tolerationSeconds: 3600
+    </code>
+  </td>
+</tr>
 </table>


### PR DESCRIPTION
Restructured Property reference page to accommodate new properties for affinity

Html temporary view (needs VPN):
https://gp-docs-mysql-120-affinity-new.sc2-04-pcf1-apps.oc.vmware.com/tanzu-mysql-kubernetes/1-1/property-reference-mysql.html

The yaml file is copied from 1.2.0 tag. It's missing persistentVolumeClaimPolicy and spec.version. 