### PR TITLE
Feature multi version support

### DIFF
--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -14,20 +14,16 @@ Before you can create or delete MySQL instances, you must have:
 
 ## <a id='download-templates'></a>  Download the Deployment Templates
 
-In order to create <%= vars.product_full %> instances, you must first download the deployment templates from Tanzu Network.
-You use these templates to create configuration files that specify the Tanzu MySQL for Kubernetes resources that you wish to create.
-
-<p class='note'><strong>Note:</strong> You only need to download the templates once (before you first create a MySQL instance).</p>
+Download the deployment templates from Tanzu Network, and use them to customize the Tanzu MySQL for Kubernetes resources that you will deploy.
 
 To access the templates:
 
-1. Log in to [<%= vars.product_network %>](https://network.pivotal.io).
+1. Log in to [<%= vars.product_network %>](https://network.pivotal.io) and visit the [Tanzu MySQL](https://network.pivotal.io/products/tanzu-mysql-for-kubernetes/) product page.
 
-1. Visit the **<%= vars.product_full %>** product page.
+1. Select **VMware Tanzu SQL with MySQL for Kubernetes v1.4.0** and download the .tgz archive file to your local machine.<br/>
+   **Note:** You do not need to download the **Artifact References** from the Tanzu MySQL for Kubernetes product page.
 
-1. Click **VMware Tanzu SQL with MySQL for Kubernetes v1.3.0**. This will download a .tgz archive file to your local machine.
-
-1. Expand the downloaded .tgz file. Open the directory `tanzu-mysql-for-kubernetes-1.3.0`. The templates are located in the `samples` subdirectory.
+1. Expand the downloaded .tgz file. Open the directory `tanzu-mysql-for-kubernetes-1.4.0`. The templates are located in the `samples` subdirectory.
 
 The templates include the following:
 
@@ -38,7 +34,8 @@ The templates include the following:
 * `restore.yaml` (for the MySQLRestore resource)
 * `tls-secret.yaml` (for a [TLS Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets))
 
-You do not need to download the **Artifact References** from the Tanzu MySQL for Kubernetes product page.
+Use these templates as a starting point for the instance creation, and backup/restore.
+
 
 ## <a id='create-instance'></a> Create a MySQL Instance
 
@@ -99,9 +96,9 @@ To create a MySQL instance:
 
 5. Edit the file and customize the instance according to your requirements. 
 
-    You may customize your Tanzu MySQL instance version, instance resources, instance storage class, storage size, high availability, node affinity and tolerations, PVC retention policy, service type (ClusterIP or LoadBalancer), and TLS secret. For details on the properties that you can set for the MySQL resource, see [Property Reference for the MySQL Resource](property-reference-mysql.html).
-
     To customize the Tanzu MySQL instance version, refer to [Specifying the Tanzu MySQL Version](#version).
+    
+    You may also customize your Tanzu MySQL instance resources, instance storage class, storage size, high availability, node affinity and tolerations, PVC retention policy, service type (ClusterIP or LoadBalancer), and TLS secret. For details on the properties that you can set for the MySQL resource, see [Property Reference for the MySQL Resource](property-reference-mysql.html).
 
 
 6. Deploy a MySQL instance to Kubernetes by running:
@@ -139,7 +136,7 @@ By default, the MySQL servers created by Tanzu Operator 1.2.0 (and later) use TL
 
 ### <a id="version"></a> Specifying the Tanzu MySQL Version
 
-The Tanzu MySQL Operator by default deploys the latest MySQL version. The Tanzu Operator 1.4.0 supports mysql-8.0.25, mysql-8.0.26, and mysql-8.0.27. To view the available Tanzu MySQL versions for your Operator, run the command:
+The Tanzu MySQL Operator by default deploys the latest MySQL version. From version 1.4.0, the Tanzu Operator supports three versions: mysql-8.0.25, mysql-8.0.26, and mysql-8.0.27. To view the available Tanzu MySQL versions for your Operator, run the command:
 
 ```
 kubectl get mysqlversions
@@ -156,8 +153,8 @@ mysql-latest   8.0.27
 ```
 
 where:
-- `NAME` denotes the 
-- `DB VERSION` displays the Percona MySQL version supported for that particular `mysql.spec.mysqlVersion` version.
+- `NAME` denotes the Tanzu MySQL version. The label `mysql-latest` deploys the latest version supported by the Tanzu MySQL Operator. For more details see [Property Reference for MySQL Resource](property-reference-mysql.html#spec).
+- `DB VERSION` displays the Percona MySQL version supported for that particular `mysql.spec.mysqlVersion` version. 
 
 Use the values under the column `NAME`  to uncomment and specify the `mysql.spec.mysqlVersion.name` field in the MySQL instance manifest:
 ```
@@ -168,12 +165,12 @@ spec:
 
 #### Specify the MySQL Version
   mysqlVersion:
-    name: mysql-8.0.27
+    name: mysql-8.0.26
 ...
 
 ```
 
-After editing the instance yaml, continue with the deployment steps in [Create a MySQL Instance](#create-instance) topic.
+After editing and saving the instance yaml, continue with the deployment steps in [Create a MySQL Instance](#create-instance) topic.
 
 To list the versions of all deployed instances, and their compatibility with the latest Operator, use:
 

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -44,6 +44,8 @@ You do not need to download the **Artifact References** from the Tanzu MySQL for
 
 [//]: # (Note to authors: if you change step numbers in this procedure, edit high-availability topic.)
 
+When you create a MySQL instance, the MySQL Operator also creates PVCs. The PVCs are attached to the instance and contain the data for the MySQL database. Single-node instances have one PVC, and high-availability (HA) instances have three. The PVC name contains the instance name and the MySQL Pod number. The PVC name is of the form `mysql-data-INSTANCE-NAME-N`, for example `mysql-data-mysql-sample-0`.
+
 ### <a id='create-inst-proc'></a> Procedure 
 
 To create a MySQL instance:
@@ -53,19 +55,21 @@ To create a MySQL instance:
     ```
     kubectl config set-context --current --namespace=DEVELOPMENT-NAMESPACE
     ```
-    Where `DEVELOPMENT-NAMESPACE` is the namespace in which you want to create the instance.
-    <br><br>
-    For example:
+    Where `DEVELOPMENT-NAMESPACE` is the namespace in which you want to create the instance. For example:
+
     ``` 
     kubectl config set-context --current --namespace=my-namespace
     ``` 
 
-2. From your namespace, Kubernetes must be able to access the registry
-   that stores the <%= vars.product_short %> images.
-   To allow this, create an imagePullSecret by running:
+2. From your namespace, Kubernetes must be able to access the registry that stores the <%= vars.product_short %> images.
+   To allow this, create an `imagePullSecret` by running:
 
     ```
-    kubectl --namespace=DEVELOPMENT-NAMESPACE create secret docker-registry tanzu-image-registry --docker-server=REGISTRY-SERVER-URL --docker-username=DOCKER-USERNAME --docker-password=DOCKER-PASSWORD
+    kubectl create secret --namespace=DEVELOPMENT-NAMESPACE \
+    docker-registry tanzu-image-registry \
+        --docker-server=REGISTRY-SERVER-URL \
+        --docker-username=DOCKER-USERNAME \
+        --docker-password=DOCKER-PASSWORD
     ```
     Where:
     * `DEVELOPMENT-NAMESPACE` is the namespace in which you want to create the instance
@@ -84,9 +88,8 @@ To create a MySQL instance:
     secret/tanzu-image-registry created
     ``` 
 
-3. Find the `mysql.yaml` deployment template that you downloaded
-   in the TGZ file from <%= vars.product_network %>.
-   For how to download deployment templates, see [Download the Deployment Templates](#download-templates).
+3. Locate the `mysql.yaml` deployment template in the TGZ file you downloaded from <%= vars.product_network %>.
+   For details on downloading deployment template, see [Download the Deployment Templates](#download-templates).
 
 4. Create a copy of the `mysql.yaml` file and give it a unique name. For example:
 
@@ -95,10 +98,10 @@ To create a MySQL instance:
     ``` 
 
 5. Edit the file and customize the instance according to your requirements. 
-    <br>
-    You may customize your Tanzu MySQL instance version, instance resources, instance storage class, storage size, high availability, node affinity and tolerations, PVC retention policy, service type (ClusterIP or LoadBalancer), and TLS secret. For more details on all the properties that you can set for the MySQL resource, see [Property Reference for the MySQL Resource](property-reference-mysql.html).
-    <br/>
-    When you create a MySQL instance, the MySQL Operator also creates PVCs. The PVCs are attached to the instance and contain the data for the MySQL database. Single-node instances have one PVC, and high-availability (HA) instances have three. The PVC name contains the instance name and the MySQL Pod number. The PVC name is of the form `mysql-data-INSTANCE-NAME-N`, for example `mysql-data-mysql-sample-0`.
+
+    You may customize your Tanzu MySQL instance version, instance resources, instance storage class, storage size, high availability, node affinity and tolerations, PVC retention policy, service type (ClusterIP or LoadBalancer), and TLS secret. For details on the properties that you can set for the MySQL resource, see [Property Reference for the MySQL Resource](property-reference-mysql.html).
+
+    To customize the Tanzu MySQL instance version, refer to [Specifying the Tanzu MySQL Version](#version).
 
 
 6. Deploy a MySQL instance to Kubernetes by running:
@@ -106,7 +109,7 @@ To create a MySQL instance:
     ```
     kubectl -n DEVELOPMENT-NAMESPACE apply -f FILENAME
     ```
-    Where `FILENAME` is the name of the configuration file you created in Step 4 above. For example:
+    Where `FILENAME` is the name of the configuration file you created. For example:
 
     ``` 
     kubectl -n my-namespace apply -f testdb.yaml
@@ -136,40 +139,62 @@ By default, the MySQL servers created by Tanzu Operator 1.2.0 (and later) use TL
 
 ### <a id="version"></a> Specifying the Tanzu MySQL Version
 
-The Tanzu MySQL Operator by default deploys the latest MySQL version.  (for Tanzu Operator 1.6.0 and 1.7.0, the MySQL version is 14.2). To view the available Tanzu MySQL versions for your Operator, run the command:
+The Tanzu MySQL Operator by default deploys the latest MySQL version. The Tanzu Operator 1.4.0 supports mysql-8.0.25, mysql-8.0.26, and mysql-8.0.27. To view the available Tanzu MySQL versions for your Operator, run the command:
 
 ```
-kubectl get MySQLversion
+kubectl get mysqlversions
 ```
 
 The command displays:
 
 ```
-NAME          DB VERSION   
-MySQL-11   11.15        
-MySQL-12   12.10         
-MySQL-13   13.6         
-MySQL-14   14.2         
+NAME           DB VERSION
+mysql-8.0.25   8.0.25
+mysql-8.0.26   8.0.26
+mysql-8.0.27   8.0.27
+mysql-latest   8.0.27     
 ```
 
 where:
-- `NAME` denotes the `MySQLVersion` CR name. Each MySQL major version has one CR. This value can be used in the MySQL manifest file to choose the MySQL version.
-- `DB VERSION` displayes the minor version supported for that particular MySQL major version.
+- `NAME` denotes the 
+- `DB VERSION` displays the Percona MySQL version supported for that particular `mysql.spec.mysqlVersion` version.
 
-Use the values under the column `NAME`  to specify the `spec.MySQLVersion.name` field in the MySQL instance manifest if you require a specific version of MySQL, for example:
-
+Use the values under the column `NAME`  to uncomment and specify the `mysql.spec.mysqlVersion.name` field in the MySQL instance manifest:
 ```
 ...
-MySQLVersion:
-  name: MySQL-13 
+metadata:
+  name: mysql-sample
+spec:
+
+#### Specify the MySQL Version
+  mysqlVersion:
+    name: mysql-8.0.27
 ...
+
 ```
 
-See [Deploying a MySQL Instance](#instance_request) on how to deploy your MySQL instance. 
+After editing the instance yaml, continue with the deployment steps in [Create a MySQL Instance](#create-instance) topic.
 
-When upgrading the Tanzu MySQL Operator, the operator will ensure that existing MySQL instances have the appropriate reference added to the object. Specifically, the operator will set `spec.MySQLVersion.name` to `MySQL-11`. If you are tracking manifest files in source control, update those manifests files to reflect the change.
-
-**IMPORTANT**: Existing MySQL instances cannot be upgraded to a different major version. 
+To list the versions of your deployed instances, use:
+```
+$ kubectl get mysql
+```
+with an output similar to:
+```
+NAME          READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION
+DBUPDALW-12   true    Running   41m    1.4.0           8.0.27       
+instance-11   true    Running   41m    1.4.0           8.0.26       
+instance-10   true    Running   41m    1.4.0           8.0.25       
+DBUPDONC-9    true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “update=once” 
+instance-8    true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “update=once” 
+instance-7    true    Running   22d    1.3.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+DBAUTOUPG-6   true    Running   120d   1.2.0           8.0.26       UpdateRequired      Annotate “update=once” 
+instance-5    true    Running   121d   1.2.0           8.0.25       UpdateRequired      Annotate “update=once”         
+instance-4    true    Running   122d   1.2.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+DBAUTOUPG-3   true    Running   150d   1.1.0           8.0.25       UpdateRequired      Annotate “update=once”           
+instance-2    true    Running   151d   1.1.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+```
 
     
 ## <a id='delete-instance'></a> Delete a Tanzu MySQL Instance

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -175,7 +175,8 @@ spec:
 
 After editing the instance yaml, continue with the deployment steps in [Create a MySQL Instance](#create-instance) topic.
 
-To list the versions of your deployed instances, use:
+To list the versions of all deployed instances, and their compatibility with the latest Operator, use:
+
 ```
 $ kubectl get mysql
 ```
@@ -195,6 +196,17 @@ DBAUTOUPG-3   true    Running   150d   1.1.0           8.0.25       UpdateRequir
 instance-2    true    Running   151d   1.1.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
 instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
 ```
+
+Where:
+
+- `TANZU VERSION` column refers to the Operator version that the instance last reconciled with.
+- `DB VERSION` column refers to the instance's current mysql DB version.
+- `UPDATE STATUS` refers to whether the instance needs an update or a DB upgrade. 
+    - An instance needs an update (value = "UpdateRequired"), if the last reconciled operator version <> current operator version. 
+    - An instance needs a DB upgrade (value = "DBUpgradeRequired"), if the current mysql version is not supported by the current operator
+- `USER ACTION` specifies the action that a user will need to take, to reconcile the instance to the current operator. 
+    - If `UPDATE STATUS`=`UpdateRequired` then `USER ACTION` should be `Annotate "mysql.with.sql.tanzu.vmware.com/update=once"`
+    - If `UPDATE STATUS`=`DBUpgradeRequired` then `USER ACTION`  should be `Set spec.mysqlVersion.name to a supported DB version`
 
     
 ## <a id='delete-instance'></a> Delete a Tanzu MySQL Instance

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -44,6 +44,8 @@ You do not need to download the **Artifact References** from the Tanzu MySQL for
 
 [//]: # (Note to authors: if you change step numbers in this procedure, edit high-availability topic.)
 
+### <a id='create-inst-proc'></a> Procedure 
+
 To create a MySQL instance:
 
 1. Target the namespace where you want to create the MySQL instance:
@@ -86,19 +88,16 @@ To create a MySQL instance:
    in the TGZ file from <%= vars.product_network %>.
    For how to download deployment templates, see [Download the Deployment Templates](#download-templates).
 
-4. Create a copy of the `mysql.yaml` file and give it a unique name.
-    <br><br>
-    For example:
+4. Create a copy of the `mysql.yaml` file and give it a unique name. For example:
 
     ``` 
     cp ~/Downloads/tanzu-mysql-deployment-templates-1.0.0/samples/mysql.yaml testdb.yaml
     ``` 
 
-
 5. Edit the file and customize the instance according to your requirements. 
     <br>
     You may customize your Tanzu MySQL instance version, instance resources, instance storage class, storage size, high availability, node affinity and tolerations, PVC retention policy, service type (ClusterIP or LoadBalancer), and TLS secret. For more details on all the properties that you can set for the MySQL resource, see [Property Reference for the MySQL Resource](property-reference-mysql.html).
-    <br><br>
+    <br/>
     When you create a MySQL instance, the MySQL Operator also creates PVCs. The PVCs are attached to the instance and contain the data for the MySQL database. Single-node instances have one PVC, and high-availability (HA) instances have three. The PVC name contains the instance name and the MySQL Pod number. The PVC name is of the form `mysql-data-INSTANCE-NAME-N`, for example `mysql-data-mysql-sample-0`.
 
 
@@ -107,9 +106,7 @@ To create a MySQL instance:
     ```
     kubectl -n DEVELOPMENT-NAMESPACE apply -f FILENAME
     ```
-    Where `FILENAME` is the name of the configuration file you created in Step 4 above.
-    <br><br>
-    For example:
+    Where `FILENAME` is the name of the configuration file you created in Step 4 above. For example:
 
     ``` 
     kubectl -n my-namespace apply -f testdb.yaml
@@ -124,8 +121,7 @@ To create a MySQL instance:
     ```
     kubectl -n DEVELOPMENT-NAMESPACE get mysql INSTANCE-NAME
     ```
-    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` in your file
-    <br><br>
+    Where `INSTANCE-NAME` is the value that you configured for `metadata.name` in your file.
     For example:
 
     ``` 
@@ -137,6 +133,44 @@ To create a MySQL instance:
     ``` 
 
 By default, the MySQL servers created by Tanzu Operator 1.2.0 (and later) use TLS certificates provided by the cert-manager `ClusterIssuer`, using a self-signed certificate authority (CA). For more information on TLS and how to configure custom a `ClusterIssuer`, see [Configuring TLS for MySQL Instances](configure-tls.html). 
+
+### <a id="version"></a> Specifying the Tanzu MySQL Version
+
+The Tanzu MySQL Operator by default deploys the latest MySQL version.  (for Tanzu Operator 1.6.0 and 1.7.0, the MySQL version is 14.2). To view the available Tanzu MySQL versions for your Operator, run the command:
+
+```
+kubectl get MySQLversion
+```
+
+The command displays:
+
+```
+NAME          DB VERSION   
+MySQL-11   11.15        
+MySQL-12   12.10         
+MySQL-13   13.6         
+MySQL-14   14.2         
+```
+
+where:
+- `NAME` denotes the `MySQLVersion` CR name. Each MySQL major version has one CR. This value can be used in the MySQL manifest file to choose the MySQL version.
+- `DB VERSION` displayes the minor version supported for that particular MySQL major version.
+
+Use the values under the column `NAME`  to specify the `spec.MySQLVersion.name` field in the MySQL instance manifest if you require a specific version of MySQL, for example:
+
+```
+...
+MySQLVersion:
+  name: MySQL-13 
+...
+```
+
+See [Deploying a MySQL Instance](#instance_request) on how to deploy your MySQL instance. 
+
+When upgrading the Tanzu MySQL Operator, the operator will ensure that existing MySQL instances have the appropriate reference added to the object. Specifically, the operator will set `spec.MySQLVersion.name` to `MySQL-11`. If you are tracking manifest files in source control, update those manifests files to reflect the change.
+
+**IMPORTANT**: Existing MySQL instances cannot be upgraded to a different major version. 
+
     
 ## <a id='delete-instance'></a> Delete a Tanzu MySQL Instance
 

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -136,7 +136,7 @@ By default, the MySQL servers created by Tanzu Operator 1.2.0 (and later) use TL
 
 ### <a id="version"></a> Specifying the Tanzu MySQL Version
 
-The Tanzu MySQL Operator by default deploys the latest MySQL version. From version 1.4.0, the Tanzu Operator supports three versions: mysql-8.0.25, mysql-8.0.26, and mysql-8.0.27. To view the available Tanzu MySQL versions for your Operator, run the command:
+The Tanzu MySQL Operator by default deploys the latest MySQL version. Beginning with version 1.4.0, the Tanzu Operator supports three versions: mysql-8.0.25, mysql-8.0.26, and mysql-8.0.27. To view the available Tanzu MySQL versions for your Operator, run the command:
 
 ```
 kubectl get mysqlversions
@@ -153,7 +153,7 @@ mysql-latest   8.0.27
 ```
 
 where:
-- `NAME` denotes the Tanzu MySQL version. The label `mysql-latest` deploys the latest version supported by the Tanzu MySQL Operator. For more details see [Property Reference for MySQL Resource](property-reference-mysql.html#spec).
+- `NAME` denotes the Tanzu MySQL version . The label `mysql-latest` deploys the latest version supported by the Tanzu MySQL Operator. For more details see [Property Reference for MySQL Resource](property-reference-mysql.html#spec).
 - `DB VERSION` displays the Percona MySQL version supported for that particular `mysql.spec.mysqlVersion` version. 
 
 Use the values under the column `NAME`  to uncomment and specify the `mysql.spec.mysqlVersion.name` field in the MySQL instance manifest:
@@ -183,15 +183,15 @@ NAME          READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATU
 DBUPDALW-12   true    Running   41m    1.4.0           8.0.27       
 instance-11   true    Running   41m    1.4.0           8.0.26       
 instance-10   true    Running   41m    1.4.0           8.0.25       
-DBUPDONC-9    true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “update=once” 
-instance-8    true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “update=once” 
+DBUPDONC-9    true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+instance-8    true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
 instance-7    true    Running   22d    1.3.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
-DBAUTOUPG-6   true    Running   120d   1.2.0           8.0.26       UpdateRequired      Annotate “update=once” 
-instance-5    true    Running   121d   1.2.0           8.0.25       UpdateRequired      Annotate “update=once”         
+DBAUTOUPG-6   true    Running   120d   1.2.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+instance-5    true    Running   121d   1.2.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”         
 instance-4    true    Running   122d   1.2.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
-DBAUTOUPG-3   true    Running   150d   1.1.0           8.0.25       UpdateRequired      Annotate “update=once”           
+DBAUTOUPG-3   true    Running   150d   1.1.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”           
 instance-2    true    Running   151d   1.1.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
-instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version                              
 ```
 
 Where:
@@ -200,10 +200,10 @@ Where:
 - `DB VERSION` column refers to the instance's current mysql DB version.
 - `UPDATE STATUS` refers to whether the instance needs an update or a DB upgrade. 
     - An instance needs an update (value = "UpdateRequired"), if the last reconciled operator version <> current operator version. 
-    - An instance needs a DB upgrade (value = "DBUpgradeRequired"), if the current mysql version is not supported by the current operator
+    - An instance needs a DB upgrade (value = "DBUpgradeRequired"), if the instance's mysql version is not supported by the current operator
 - `USER ACTION` specifies the action that a user will need to take, to reconcile the instance to the current operator. 
-    - If `UPDATE STATUS`=`UpdateRequired` then `USER ACTION` should be `Annotate "mysql.with.sql.tanzu.vmware.com/update=once"`
-    - If `UPDATE STATUS`=`DBUpgradeRequired` then `USER ACTION`  should be `Set spec.mysqlVersion.name to a supported DB version`
+    - If `UPDATE STATUS`=`UpdateRequired` then `USER ACTION` will display the text `Annotate "mysql.with.sql.tanzu.vmware.com/update=once"`
+    - If `UPDATE STATUS`=`DBUpgradeRequired` then `USER ACTION`  will display the text `Set spec.mysqlVersion.name to a supported DB version`
 
     
 ## <a id='delete-instance'></a> Delete a Tanzu MySQL Instance

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -145,9 +145,12 @@ The name of the MySQL instance. Must be unique within a namespace. Cannot be mod
 **`mysqlversion: <String>`**<br />
 **Optional**<br />
 **Default**: <latest MySQL release supported><br />
-Indicates the MySQL version installed. By default it installs the latest supported version of MySQL. For example, ff the Operator supports {mysql-8.0.25, mysql-8.0.26, mysql-8.0.27}, then this value will default to mysql-8.0.27.
-After Tanzu MySQL Operator 1.4.0 release, each Operator supports three MySQL versions. Tanzu MySQL Operator 1.4.0 supports  <br />
-**Example**: 50Gi
+Indicates the MySQL version that will be deployed. By default it installs the latest supported version. For example, if the Tanzu MySQL Operator supports mysql-8.0.25, mysql-8.0.26, mysql-8.0.27, this value defaults to mysql-8.0.27.<br/>
+From Tanzu MySQL Operator 1.4.0 release, three MySQL versions are supported at any time. Only the permitted version strings are valid input for the field. Entries that do not match a supported version generate an error. Use `kubectl get mysqlVersion` to verify the MySQL versions of your Operator release.  <br />
+Use the "floating version tag" `mysql-latest` to configure your instance to always upgrade to the latest MySQL version supported by future Operator upgrades.<br/>
+**WARNING**: Instances with `mysql-latest` version will automatically reboot and upgrade when the Operator gets upgraded.
+**Example**:<br/>
+`mysql-8.0.26`
 
 **`storageSize: <Quantity>`**<br />
 **Optional**<br />

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -145,13 +145,13 @@ The name of the MySQL instance. Must be unique within a namespace. Cannot be mod
 **`mysqlversion: <String>`**<br />
 **Optional**<br />
 **Default**: <latest MySQL release supported><br />
-Indicates the MySQL version that will be deployed. By default it installs the latest supported version. For example, if the Tanzu MySQL Operator supports mysql-8.0.25, mysql-8.0.26, mysql-8.0.27, this value defaults to mysql-8.0.27.<br/>
+The MySQL version that will be used for creating an instance. If the user does not specify a value, the latest supported version will be used as the default. For example, if the Tanzu MySQL Operator supports mysql-8.0.25, mysql-8.0.26, mysql-8.0.27, this value defaults to mysql-8.0.27.<br/>
 From Tanzu MySQL Operator 1.4.0 release, three MySQL versions are supported at any time. Only the permitted version strings are valid input for the field. Entries that do not match a supported version generate an error. Use `kubectl get mysqlVersion` to verify the MySQL versions of your Operator release.  <br />
 Use the "floating version tag" `mysql-latest` to configure your instance to always upgrade to the latest MySQL version supported by future Operator upgrades.<br/>
-**WARNING**: Instances with `mysql-latest` version will automatically reboot and upgrade when the Operator gets upgraded.
 **Example**:<br/>
 `mysql-8.0.26`
-
+**WARNING**: Instances with `mysql-latest` version will automatically reboot and upgrade when the Operator gets upgraded in the future.
+  
 **`storageSize: <Quantity>`**<br />
 **Optional**<br />
 **Default**: 1Gi<br />
@@ -176,12 +176,6 @@ The StorageClass used for PVCs associated with MySQL instance Pods. Cannot be mo
 **Default**: ClusterIP<br />
 The type of Service used to provide access to the MySQL database. Only `ClusterIP` and `LoadBalancer` are supported. For more information about Kubernetes ServiceTypes, see the [Service Types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) in the Kubernetes documentation.<br />
 **Example**: LoadBalancer
-
-**`version: <string>`**<br />
-**Optional**<br />
-**Default**: The value of `defaultInstanceVersion` set by the service administrator in the Tanzu MySQL Helm chart. <br />
-The version of the MySQL instance installed. Can be any of '1.0.0', '1.3.0', or '1.2.0'. See [List Instances By Version](upgrade-instance.html#list-instances-by-version).<br />
-**Example**: 1.3.0
 
 **`tls.secret.name: <string>`**<br />
 **Optional**<br />

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -13,6 +13,10 @@ metadata:
   name: mysql-sample
 spec:
 
+#### Specify the MySQL Version
+#  mysqlVersion:
+#    name: mysql-8.0.26
+
 #### Set the storage size for the database persistent storage volume
 #  storageSize: 1Gi
 
@@ -137,6 +141,13 @@ The name of the MySQL instance. Must be unique within a namespace. Cannot be mod
 
 
 ## <a id="spec"></a> Spec
+
+**`mysqlversion: <String>`**<br />
+**Optional**<br />
+**Default**: <latest MySQL release supported><br />
+Indicates the MySQL version installed. By default it installs the latest supported version of MySQL. For example, ff the Operator supports {mysql-8.0.25, mysql-8.0.26, mysql-8.0.27}, then this value will default to mysql-8.0.27.
+After Tanzu MySQL Operator 1.4.0 release, each Operator supports three MySQL versions. Tanzu MySQL Operator 1.4.0 supports  <br />
+**Example**: 50Gi
 
 **`storageSize: <Quantity>`**<br />
 **Optional**<br />

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -150,7 +150,7 @@ From Tanzu MySQL Operator 1.4.0 release, three MySQL versions are supported at a
 Use the "floating version tag" `mysql-latest` to configure your instance to always upgrade to the latest MySQL version supported by future Operator upgrades.<br/>
 **Example**:<br/>
 `mysql-8.0.26`
-**WARNING**: Instances with `mysql-latest` version will automatically reboot and upgrade when the Operator gets upgraded in the future.
+**WARNING**: After an Operator upgrade, instances with `mysqlVersion.name` as`mysql-latest` will automatically reboot and upgrade to the latest supported MySQL version for that Operator. 
   
 **`storageSize: <Quantity>`**<br />
 **Optional**<br />


### PR DESCRIPTION
These doc changes introduce the new field and the new command. This topic does not deal with the workflow of upgrading instances. 

html version of staging:

https://docs-staging.vmware.com/en/VMware-Tanzu-SQL-with-MySQL-for-Kubernetes/wip_multi_version/tanzu-mysql-k8s/GUID-create-delete-mysql.html
