### PR TITLE
Feature - multiversion upgrade and update

### DIFF
--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -196,11 +196,11 @@ instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeReq
 
 Where:
 
-- `TANZU VERSION` column refers to the Operator version that the instance last reconciled with.
-- `DB VERSION` column refers to the instance's current mysql DB version.
-- `UPDATE STATUS` refers to whether the instance needs an update or a DB upgrade. 
-    - An instance needs an update (value = "UpdateRequired"), if the last reconciled operator version <> current operator version. 
-    - An instance needs a DB upgrade (value = "DBUpgradeRequired"), if the instance's mysql version is not supported by the current operator
+- `TANZU VERSION` column refers to the Operator version that the instance was last reconciled with.
+- `DB VERSION` column refers to the instance's current MySQL database version.
+- `UPDATE STATUS` refers to whether the instance needs an update or a database version upgrade. 
+    - An instance needs an update (value = "UpdateRequired"), if the last reconciled Operator version is different to the current Operator version. 
+    - An instance needs a MySQL version upgrade (value = "DBUpgradeRequired"), if the instance's MySQL version is not supported by the current Operator.
 - `USER ACTION` specifies the action that a user will need to take, to reconcile the instance to the current operator. 
     - If `UPDATE STATUS`=`UpdateRequired` then `USER ACTION` will display the text `Annotate "mysql.with.sql.tanzu.vmware.com/update=once"`
     - If `UPDATE STATUS`=`DBUpgradeRequired` then `USER ACTION`  will display the text `Set spec.mysqlVersion.name to a supported DB version`

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -100,7 +100,6 @@ To create a MySQL instance:
     
     You may also customize your Tanzu MySQL instance resources, instance storage class, storage size, high availability, node affinity and tolerations, PVC retention policy, service type (ClusterIP or LoadBalancer), and TLS secret. For details on the properties that you can set for the MySQL resource, see [Property Reference for the MySQL Resource](property-reference-mysql.html).
 
-
 6. Deploy a MySQL instance to Kubernetes by running:
 
     ```
@@ -114,7 +113,6 @@ To create a MySQL instance:
     ```
     mysql.with.sql.tanzu.vmware.com/mysql-sample created
     ``` 
-
 
 7. Verify that the instance was created successfully by running:
 
@@ -131,12 +129,12 @@ To create a MySQL instance:
     NAME           READY   STATUS    AGE
     mysql-sample   true    Running   2m17s
     ``` 
+8. Review [Configuring TLS for MySQL Instances](configure-tls.html) if you need to configure a custom `ClusterIssuer`. By default, the MySQL instances created by Tanzu Operator 1.2.0 (and later) use TLS certificates provided by the cert-manager `ClusterIssuer`, using a self-signed certificate authority (CA). 
 
-By default, the MySQL servers created by Tanzu Operator 1.2.0 (and later) use TLS certificates provided by the cert-manager `ClusterIssuer`, using a self-signed certificate authority (CA). For more information on TLS and how to configure custom a `ClusterIssuer`, see [Configuring TLS for MySQL Instances](configure-tls.html). 
 
 ### <a id="version"></a> Specifying the Tanzu MySQL Version
 
-The Tanzu MySQL Operator by default deploys the latest MySQL version. Beginning with version 1.4.0, the Tanzu Operator supports three versions: mysql-8.0.25, mysql-8.0.26, and mysql-8.0.27. To view the available Tanzu MySQL versions for your Operator, run the command:
+The Tanzu MySQL Operator by default deploys the latest MySQL databases version. Beginning with the release of the Tanzu Operator 1.4.0, the Operator supports three versions: mysql-8.0.25, mysql-8.0.26, and mysql-8.0.27. To view the available Tanzu MySQL versions for your Operator, run the command:
 
 ```
 kubectl get mysqlversions
@@ -153,10 +151,10 @@ mysql-latest   8.0.27
 ```
 
 where:
-- `NAME` denotes the Tanzu MySQL version . The label `mysql-latest` deploys the latest version supported by the Tanzu MySQL Operator. For more details see [Property Reference for MySQL Resource](property-reference-mysql.html#spec).
+- `NAME` denotes the Tanzu MySQL version. The label `mysql-latest` deploys the latest version supported by the Tanzu MySQL Operator. For more details see [Property Reference for MySQL Resource](property-reference-mysql.html#spec).
 - `DB VERSION` displays the Percona MySQL version supported for that particular `mysql.spec.mysqlVersion` version. 
 
-Use the values under the column `NAME`  to uncomment and specify the `mysql.spec.mysqlVersion.name` field in the MySQL instance manifest:
+Use one of the values under the column `NAME` to uncomment, and specify the `mysql.spec.mysqlVersion.name` field in the MySQL instance manifest:
 ```
 ...
 metadata:
@@ -171,39 +169,6 @@ spec:
 ```
 
 After editing and saving the instance yaml, continue with the deployment steps in [Create a MySQL Instance](#create-instance) topic.
-
-To list the versions of all deployed instances, and their compatibility with the latest Operator, use:
-
-```
-$ kubectl get mysql
-```
-with an output similar to:
-```
-NAME          READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION
-DBUPDALW-12   true    Running   41m    1.4.0           8.0.27       
-instance-11   true    Running   41m    1.4.0           8.0.26       
-instance-10   true    Running   41m    1.4.0           8.0.25       
-DBUPDONC-9    true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
-instance-8    true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
-instance-7    true    Running   22d    1.3.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
-DBAUTOUPG-6   true    Running   120d   1.2.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
-instance-5    true    Running   121d   1.2.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”         
-instance-4    true    Running   122d   1.2.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
-DBAUTOUPG-3   true    Running   150d   1.1.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”           
-instance-2    true    Running   151d   1.1.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
-instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version                              
-```
-
-Where:
-
-- `TANZU VERSION` column refers to the Operator version that the instance was last reconciled with.
-- `DB VERSION` column refers to the instance's current MySQL database version.
-- `UPDATE STATUS` refers to whether the instance needs an update or a database version upgrade. 
-    - An instance needs an update (value = "UpdateRequired"), if the last reconciled Operator version is different to the current Operator version. 
-    - An instance needs a MySQL version upgrade (value = "DBUpgradeRequired"), if the instance's MySQL version is not supported by the current Operator.
-- `USER ACTION` specifies the action that a user will need to take, to reconcile the instance to the current operator. 
-    - If `UPDATE STATUS`=`UpdateRequired` then `USER ACTION` will display the text `Annotate "mysql.with.sql.tanzu.vmware.com/update=once"`
-    - If `UPDATE STATUS`=`DBUpgradeRequired` then `USER ACTION`  will display the text `Set spec.mysqlVersion.name to a supported DB version`
 
     
 ## <a id='delete-instance'></a> Delete a Tanzu MySQL Instance

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -126,8 +126,8 @@ To create a MySQL instance:
     kubectl -n my-namespace get mysql mysql-sample
     ```
     ```
-    NAME           READY   STATUS    AGE
-    mysql-sample   true    Running   2m17s
+    NAME           READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION
+    mysql-sample   true    Running   162m   1.4.0           8.0.27       NoUpdateRequired
     ``` 
 8. Review [Configuring TLS for MySQL Instances](configure-tls.html) if you need to configure a custom `ClusterIssuer`. By default, the MySQL instances created by Tanzu Operator 1.2.0 (and later) use TLS certificates provided by the cert-manager `ClusterIssuer`, using a self-signed certificate authority (CA). 
 
@@ -154,7 +154,7 @@ where:
 - `NAME` denotes the Tanzu MySQL version. The label `mysql-latest` deploys the latest version supported by the Tanzu MySQL Operator. For more details see [Property Reference for MySQL Resource](property-reference-mysql.html#spec).
 - `DB VERSION` displays the Percona MySQL version supported for that particular `mysql.spec.mysqlVersion` version. 
 
-Use one of the values under the column `NAME` to uncomment, and specify the `mysql.spec.mysqlVersion.name` field in the MySQL instance manifest:
+Use one of the values under the column `NAME`, and specify the `mysql.spec.mysqlVersion.name` field in the MySQL instance manifest:
 ```
 ...
 metadata:

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -5,8 +5,8 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-This topic describes how to scale or change configurations on a
-<%= vars.product_full %> instance.
+This topic describes how to scale, or change configurations on a
+<%= vars.product_full %> instance. It also covers how to update a Tanzu MySQL instance after an Operator upgrade. 
 
 ## <a id='prereq'></a> Prerequisites
 
@@ -16,7 +16,60 @@ Before you update the MySQL instance, you must have:
 
 * **The Kubernetes Command Line Interface (kubectl) installed:**
 For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+* **An upgraded Operator** This prerequisite is not applicable to users that are only updating instance configuration details. 
 
+## <a id='update-instance'></a> Updating an Instance Version
+
+1. After an Operator upgrade, review the Operators supported MySQL versions by running:
+
+    ```
+    kubectl get mysqlversions
+    ```
+    
+    The command displays an ouput similar to:
+    
+    ```
+    NAME           DB VERSION
+    mysql-8.0.25   8.0.25
+    mysql-8.0.26   8.0.26
+    mysql-8.0.27   8.0.27
+    mysql-latest   8.0.27     
+    ```
+
+1. List the state of your existing instances, to verify any expected user actions, which are calculated based on the new Operator supported MySQL versions.
+
+    ```
+    $ kubectl get mysql
+    ```
+    The output is similar to:
+    
+    ```
+    NAME          READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION
+         
+    DBUPDONC-9    true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+    instance-8    true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+    instance-7    true    Running   22d    1.3.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+    DBAUTOUPG-6   true    Running   120d   1.2.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+    instance-5    true    Running   121d   1.2.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”         
+    instance-4    true    Running   122d   1.2.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+    DBAUTOUPG-3   true    Running   150d   1.1.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”           
+    instance-2    true    Running   151d   1.1.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+    instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version                              
+    ```
+
+1. Check the `UPDATE STATUS` column. Note the instances with an update value = "UpdateRequired". These instances have a supported MySQL version under the upgraded Operator, but need to be brought up-to-date or reconciled, to maintain a self healing Kubernetes profile. After the annotate action, these instances can use all the new features of the upgraded Operator.
+
+1. As per the `USER ACTION` column, use the Kubernetes method of Annotations to push a one time action. 
+
+    **WARNING**: Annotating an instance will cause instance reboot. Plan your instance annotations according to your applications and maintenance windows. 
+    
+    The `USER ACTION` text `Annotate "mysql.with.sql.tanzu.vmware.com/update=once"` requires the user to run a command similar to:
+
+    ```
+    kubectl annotate mysql instance-8 mysql.with.sql.tanzu.vmware.com/update=once
+    ```
+
+    The annotation is removed the moment the instance update is complete. You may rerun the command `kubectl get mysql` to verify that the reconciliation is complete.
 
 ## <a id='scale-storage'></a> Scale storageSize
 

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -16,11 +16,11 @@ Before you update the MySQL instance, you must have:
 
 * **The Kubernetes Command Line Interface (kubectl) installed:**
 For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-* **An upgraded Operator** This prerequisite is not applicable to users that are only updating instance configuration details. 
+* **An upgraded Operator**: This prerequisite is not applicable to users that are only updating instance configuration details. 
 
-## <a id='update-instance'></a> Updating an Instance Version
+## <a id='update-instance'></a> Updating an Instance 
 
-1. After an Operator upgrade, review the Operators supported MySQL versions by running:
+1. After an Operator upgrade, review the Operator's supported MySQL versions by running:
 
     ```
     kubectl get mysqlversions
@@ -35,8 +35,10 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
     mysql-8.0.27   8.0.27
     mysql-latest   8.0.27     
     ```
+    
+    The list indicates the three versions that are supported by this specific Operator you upgraded to. 
 
-1. List the state of your existing instances, to verify any expected user actions, which are calculated based on the new Operator supported MySQL versions.
+1. List the of your existing instances, to verify any expected user actions. The user actions are estimated based on the Operator supported MySQL versions. From Tanzu Operator 1.4.0 the output of the `kubectl get mysql` command has been enhanced to include `UPDATE STATUS` and `USER ACTION` column. 
 
     ```
     $ kubectl get mysql
@@ -46,6 +48,7 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
     ```
     NAME          READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION
          
+    instance-10   true    Running   41m    1.4.0           8.0.25
     DBUPDONC-9    true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
     instance-8    true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
     instance-7    true    Running   22d    1.3.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
@@ -57,11 +60,11 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
     instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version                              
     ```
 
-1. Check the `UPDATE STATUS` column. Note the instances with an update value = "UpdateRequired". These instances have a supported MySQL version under the upgraded Operator, but need to be brought up-to-date or reconciled, to maintain a self healing Kubernetes profile. After the annotate action, these instances can use all the new features of the upgraded Operator.
+1. Check the `UPDATE STATUS` column. Note the instances with an update value = "UpdateRequired". These instances have a supported MySQL version under the upgraded Operator, but need to be brought up-to-date or reconciled, to maintain a self healing Kubernetes profile. 
 
-1. As per the `USER ACTION` column, use the Kubernetes method of Annotations to push a one time action. 
+1. As per the `USER ACTION` column, use the Kubernetes method of Annotations to push a one time action. After the annotate action, these instances can use all the new features of the upgraded Operator.
 
-    **WARNING**: Annotating an instance will cause instance reboot. Plan your instance annotations according to your applications and maintenance windows. 
+    **WARNING**: Annotating an instance will cause instance reboot. Plan your instance annotations according to your applications maintenance windows. 
     
     The `USER ACTION` text `Annotate "mysql.with.sql.tanzu.vmware.com/update=once"` requires the user to run a command similar to:
 

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -51,7 +51,7 @@ After an Operator upgrade, instances created under an older Operator require rec
     ```
     NAME          READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION
          
-    instance-10   true    Running   41m    1.4.0           8.0.25
+    instance-10   true    Running   41m    1.4.0           8.0.25       NoUpdateRequired
     DBUPDONC-9    true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
     instance-8    true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
     instance-7    true    Running   22d    1.3.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
@@ -63,7 +63,7 @@ After an Operator upgrade, instances created under an older Operator require rec
     instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version                              
     ```
 
-1. Check the `UPDATE STATUS` column and note the instances with an update value = "UpdateRequired". These instances are under a supported MySQL version, but were created using an older Operator. These instances need to be brought up-to-date or reconciled, to maintain a self healing Kubernetes profile. 
+1. Check the `UPDATE STATUS` column and note the instances with an update value = "UpdateRequired". These instances need to be brought up-to-date or reconciled, to take advantage of new Operator features, and the self-healing capabilities that are native to Kubernetes. 
 
 1. As per the `USER ACTION` column, use the Kubernetes method of Annotations to push a one time action. 
 

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -20,7 +20,10 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
 
 ## <a id='update-instance'></a> Updating an Instance 
 
-1. After an Operator upgrade, review the Operator's supported MySQL versions by running:
+After an Operator upgrade, instances created under an older Operator require reconciliation. Reconciliation allows the older instances to take advantage of the new features of the upgraded Operator. 
+
+
+ 1. Review the Operator's supported MySQL versions by running:
 
     ```
     kubectl get mysqlversions
@@ -36,9 +39,9 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
     mysql-latest   8.0.27     
     ```
     
-    The list indicates the three versions that are supported by this specific Operator you upgraded to. 
+    The list indicates the three versions the Operator supports. 
 
-1. List the of your existing instances, to verify any expected user actions. The user actions are estimated based on the Operator supported MySQL versions. From Tanzu Operator 1.4.0 the output of the `kubectl get mysql` command has been enhanced to include `UPDATE STATUS` and `USER ACTION` column. 
+1. Check the status of your existing instances, to identify any recommended reconciliations. From Tanzu Operator 1.4.0 the output of `kubectl get mysql` command has been enhanced to include an `UPDATE STATUS`, and an `USER ACTION` column. 
 
     ```
     $ kubectl get mysql
@@ -60,9 +63,9 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
     instance-1    true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version                              
     ```
 
-1. Check the `UPDATE STATUS` column. Note the instances with an update value = "UpdateRequired". These instances have a supported MySQL version under the upgraded Operator, but need to be brought up-to-date or reconciled, to maintain a self healing Kubernetes profile. 
+1. Check the `UPDATE STATUS` column and note the instances with an update value = "UpdateRequired". These instances are under a supported MySQL version, but were created using an older Operator. These instances need to be brought up-to-date or reconciled, to maintain a self healing Kubernetes profile. 
 
-1. As per the `USER ACTION` column, use the Kubernetes method of Annotations to push a one time action. After the annotate action, these instances can use all the new features of the upgraded Operator.
+1. As per the `USER ACTION` column, use the Kubernetes method of Annotations to push a one time action. 
 
     **WARNING**: Annotating an instance will cause instance reboot. Plan your instance annotations according to your applications maintenance windows. 
     
@@ -72,7 +75,7 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
     kubectl annotate mysql instance-8 mysql.with.sql.tanzu.vmware.com/update=once
     ```
 
-    The annotation is removed the moment the instance update is complete. You may rerun the command `kubectl get mysql` to verify that the reconciliation is complete.
+    The annotation is removed the moment the instance update is complete. You may rerun the command `kubectl get mysql` to verify that the reconciliation is complete. After the annotate action, these instances can use all the new features of the latest Operator.
 
 ## <a id='scale-storage'></a> Scale storageSize
 

--- a/upgrade-instance.html.md.erb
+++ b/upgrade-instance.html.md.erb
@@ -20,7 +20,7 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
 
 ## <a id='list-instances-by-version'></a> List Instance Versions 
 
-From Tanzu MySQL Operator 1.4.0, each MySQL instance has a `spec.mysqlVersion.name` label containing the version of the MySQL instance. Every Tanzu MySQL Operator after 1.4.0 release supports three MySQL versions, giving the customers the flexibility to specify their preference, and upgrade to a later MySQL version. 
+Tanzu MySQL Operator 1.4.0 supports a new MySQL instance property `spec.mysqlVersion.name`, that can be used to specify a MySQL version that a user needs. Every Tanzu MySQL Operator after 1.4.0 release supports three MySQL versions, giving the customers the flexibility to specify their preference, and upgrade to a later MySQL version. 
 
 <p class='note'><strong>NOTE:</strong>  Upgrading the MySQL Operator does not automatically upgrade any existing MySQL instances. Any instance upgrades require user intervention.</p>
 
@@ -55,7 +55,7 @@ Tanzu Operator 1.4.0 supports two additional columns to help users identify upgr
     with an output similar to:
     ```
     NAME           READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION      
-    mysql-sample   true    Running   41m    1.4.0           8.0.26              
+    mysql-sample   true    Running   41m    1.4.0           8.0.26       NoUpdateRequired       
     DBUPDONC-9     true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
     instance-8     true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
     instance-7     true    Running   22d    1.3.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version

--- a/upgrade-instance.html.md.erb
+++ b/upgrade-instance.html.md.erb
@@ -129,3 +129,5 @@ Tanzu Operator 1.4.0 supports two additional columns to help users identify upgr
     instance-7     true    Running   22d    1.4.0           8.0.26       NoUpdateRequired   
     ```
     
+    For instances requiring an update (`UPDATE STATUS`="UpdateRequired"), refer to [Updating an Instance](update-instance.html#update-instance).
+    

--- a/upgrade-instance.html.md.erb
+++ b/upgrade-instance.html.md.erb
@@ -5,7 +5,7 @@ owner: MySQL
 
 <strong><%= modified_date %></strong>
 
-This topic describes how to upgrade a <%= vars.product_short %> instance after [upgrading the operator](./upgrade-operator.html).
+This topic describes how to upgrade a <%= vars.product_short %> instance after [Upgrading the Operator](./upgrade-operator.html).
 
 ## <a id='prereq'></a> Prerequisites
 
@@ -18,122 +18,114 @@ Before you upgrade a MySQL instance, you must have:
 * **The Kubernetes Command Line Interface (kubectl) installed.**
 For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
-## <a id='list-instances-by-version'></a> List Instances By Version
+## <a id='list-instances-by-version'></a> List Instance Versions 
 
-Each MySQL instance has a `version` label containing the version of the instance. The instance version corresponds to a version of <%= vars.product_short %>.
+From Tanzu MySQL Operator 1.4.0, each MySQL instance has a `spec.mysqlVersion.name` label containing the version of the MySQL instance. Every Tanzu MySQL Operator after 1.4.0 release supports three MySQL versions, giving the customers the flexibility to specify their preference, and upgrade to a later MySQL version. 
 
-<p class='note'><strong>Note:</strong> The <code>version</code> label was added in Tanzu MySQL for Kubernetes version 1.1.0. Upgrading the MySQL operator to version 1.1.0 or later causes the <code>version</code> label to be applied to existing MySQL instances automatically.</p>
+<p class='note'><strong>NOTE:</strong>  Upgrading the MySQL Operator does not automatically upgrade any existing MySQL instances. Any instance upgrades require user intervention.</p>
 
-To list all MySQL instances at a specific version, run:
+To list the supported MySQL versions for a specific Operator, run:
 
 ```
-kubectl get mysql -l app.kubernetes.io/version=VERSION
+kubectl get mysqlversions
 ```
 
-Where `VERSION` is the version of <%= vars.product_full %>.
+The command displays an ouput similar to:
 
-For example:
-
-``` 
-kubectl get mysql -l app.kubernetes.io/version=1.0.0
 ```
+NAME           DB VERSION
+mysql-8.0.25   8.0.25
+mysql-8.0.26   8.0.26
+mysql-8.0.27   8.0.27
+mysql-latest   8.0.27     
 ```
-NAME           READY   STATUS    VERSION   AGE
-mysql-sample   true    Running   1.0.0     22m
-``` 
+For a mapping of the Tanzu Operator version, with the corresponding instance version(s) supported with that Operator, review the table under [Software Component Versions](release-notes.html#components) in the release notes.
 
 ## <a id='upgrade-steps'></a> Upgrade an Instance
 
-Each <%= vars.product_full %> instance is based on a copy of the `mysql.yaml` deployment template file. The file for the instance should have a unique name (for example, `testdb.yaml`). To upgrade an instance, you must edit this configuration file.
+Tanzu Operator 1.4.0 supports two additional columns to help users identify upgrade actions for existing instances. 
 
-To upgrade a MySQL instance:
+**WARNING**: User actions specified under the `USER ACTION` column result in instance reboot. Ensure these actions are executed during an agreed maintenance window.
 
-1. List all the instances across all namespaces in the cluster:
-   
+1. List the versions of all deployed instances, and their compatibility with the latest Operator by running:
+
     ```
-    kubectl get mysql -A
+    $ kubectl get mysql
     ```
-    which returns an output similar to:
-    ``` 
-    NAMESPACE        NAME             READY   STATUS    VERSION   AGE
-    my-namespace     mysql-sample-2   true    Running   1.0.0     2h31m
-    acceptance       mysql-sample     true    Running   1.1.0     6h42m
-    ``` 
+    with an output similar to:
+    ```
+    NAME           READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION      
+    mysql-sample   true    Running   41m    1.4.0           8.0.26              
+    DBUPDONC-9     true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+    instance-8     true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+    instance-7     true    Running   22d    1.3.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+    DBAUTOUPG-6    true    Running   120d   1.2.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+    instance-5     true    Running   121d   1.2.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”         
+    instance-4     true    Running   122d   1.2.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+    DBAUTOUPG-3    true    Running   150d   1.1.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”           
+    instance-2     true    Running   151d   1.1.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
+    instance-1     true    Running   202d   1.0.0           8.0.23       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version                              
+    ```
+    
+    Where:
+    
+    - `TANZU VERSION` column refers to the Operator version that the instance was last reconciled (synchronized) with. 
+    - `DB VERSION` column refers to the instance's current MySQL database version.
+    - `UPDATE STATUS` refers to whether the instance needs an update or a database version upgrade. 
+        - "UpdateRequired" indicates that the instance's last reconciled Operator version is different to the current Operator version. For more details, see [Updating an Instance](update-instance.html#update-instance).
+        - "DBUpgradeRequired" indicates that an instance needs a MySQL database version upgrade. The instance's current MySQL version is not supported by the current Operator. Follow the remaining steps in this topic.
+    - `USER ACTION` specifies the user action required to ensure the MySQL instances are under a supported version, or the need for reconciliation.
 
-2. Target the namespace of the MySQL instance:
+1. For each of the instances with `UPDATE STATUS`=`DBUpgradeRequired`, target the namespace of the MySQL instance:
 
     ```
     kubectl config set-context --current --namespace=DEVELOPMENT-NAMESPACE
     ```
-    Where `DEVELOPMENT-NAMESPACE` is the namespace in which the instance was created.
-    <br><br>
-    For example:
+    Where `DEVELOPMENT-NAMESPACE` is the namespace in which the instance was created. For example:
     ``` 
     kubectl config set-context --current --namespace=my-namespace
     ``` 
 
-3. Edit the configuration file for the MySQL instance, setting the `spec.version` property to the desired new version. (This property was added in <%= vars.product_full %> version 1.1.0.)
-    <br><br>
-    For example:
+1. Edit the configuration file for the MySQL instance, setting the `spec.mysqlVersion.name` property to the desired new version. For example:
 
     ```
     ---
     apiVersion: with.sql.tanzu.vmware.com/v1
     kind: MySQL
     metadata:
-      name: mysql-sample
+      name: instance-7
     spec:
-      version: 1.3.0
+      mysqlVersion:
+        name: mysql-8.0.26
       ...
     ```
 
-4. If you are upgrading the instance from <%= vars.product_full %> version 1.0 to version 1.1, you may need to update the `spec.imagePullSecret` property. In version 1.1.0, this property was renamed to `imagePullSecretName`, and the default secret name was changed from `tanzu-mysql-image-registry` to `tanzu-image-registry`. Make sure that you use the correct property name and value in the configuration file for the MySQL instance.
-    <br /><br />
-    For example, if you wish to continue using a secret named `tanzu-mysql-image-registry`:
-
-    ```
-    ---
-    apiVersion: with.sql.tanzu.vmware.com/v1
-    kind: MySQL
-    metadata:
-      name: mysql-sample
-    spec:
-      version: 1.3.0
-      imagePullSecretName: tanzu-mysql-image-registry
-      ...
-    ```
-
-    Alternatively, you can remove the property from the configuration file. If you remove the property, the MySQL instance will use the `imagePullSecretName` specified in the `values-override.yaml` or `values.yaml` file for the MySQL operator.</p>
-
-5. Apply your changes by running:
+1. Apply the changes by running:
 
     ```
     kubectl apply -f FILENAME
     ```
-    Where `FILENAME` is the name of the configuration file.
-    <br><br>
-    For example:
+    Where `FILENAME` is the name of the configuration file. For example:
 
     ``` 
-    kubectl apply -f testdb.yaml
+    kubectl apply -f instance-7-db.yaml
     ```
     ```
     mysql.with.sql.tanzu.vmware.com/mysql-sample configured
     ``` 
 
-6. Verify that the instance was upgraded successfully by running:
+1. Verify that the instance was upgraded successfully by running:
 
     ```
-    kubectl get mysql INSTANCE-NAME
+    kubectl get mysql 
     ```
-    Where `INSTANCE-NAME` is the value configured for `metadata.name` in the configuration file.
-    <br><br>
-    When the instance has been successfully upgraded, the value of the `READY` column for the instance should be `true` and the value of the `VERSION` column for the instance should report the new version. For example:
+    The `UPDATE STATUS` column of the instance should display `NoUpdateRequired`. The `TANZU VERSION` should display the latest Operator.
 
-    ``` 
-    kubectl get mysql mysql-sample
     ```
+    NAME           READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION      
+    mysql-sample   true    Running   41m    1.4.0           8.0.26              
+    DBUPDONC-9     true    Running   20d    1.3.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+    instance-8     true    Running   21d    1.3.0           8.0.25       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once” 
+    instance-7     true    Running   22d    1.4.0           8.0.26       NoUpdateRequired   
     ```
-    NAME           READY   STATUS    VERSION   AGE
-    mysql-sample   true    Running   1.3.0     24m
-    ``` 
+    

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -100,3 +100,5 @@ The value of `REGISTRY-URL` has the following pattern:
 	```
 	rm ${CHART_DIR}
 	```
+
+1. After upgradeding the Operator, check the status of your existing instances and plan for an upgrade or an update. Review [Upgrading an Instance]() and [Updating an Instance Version](update-instance.html#update-instance). 

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -4,15 +4,12 @@ owner: MySQL
 ---
 
 
-This topic describes how operators upgrade the <%= vars.product_full %> Operator.
+This topic describes how to upgrade the <%= vars.product_full %> Operator.
 
-## <a id="upgrade-operator"></a>  Use the Helm CLI to Upgrade the Operator
+## <a id="upgrade-operator"></a>  Upgrade the Operator using Helm CLI
 
-To upgrade <%= vars.product_short %>, you must download resources and upgrade
+To upgrade <%= vars.product_short %>, you must download the resources, and upgrade
 the <%= vars.product_short %> Operator using Helm.
-
-To upgrade the Operator using the Helm CLI:
-
 
 1. Set the environment variable to enable OCI support in the Helm v3 client by running:
 

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -100,4 +100,6 @@ To upgrade the Operator using the Helm CLI:
 
 1. Check the status of your existing instances, and plan for an upgrade or an update. 
 
-    Use the command `kubectl get mysqls` and review [Upgrading an Instance](upgrade-instance.html#upgrade-steps) and [Updating an Instance Version](update-instance.html#update-instance). 
+    Use the command `kubectl get mysqls` and review [List Instance Versions](upgrade-instance.html#upgrade-steps), [Upgrade an Instance](upgrade-instance.html#upgrade-steps) and [Updating an Instance](update-instance.html#update-instance). 
+
+    

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -98,5 +98,3 @@ the <%= vars.product_short %> Operator using Helm.
 1. Check the status of your existing instances, and plan for an upgrade or an update. 
 
     Use the command `kubectl get mysqls` and review [List Instance Versions](upgrade-instance.html#upgrade-steps), [Upgrade an Instance](upgrade-instance.html#upgrade-steps) and [Updating an Instance](update-instance.html#update-instance). 
-
-    

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -58,17 +58,14 @@ To upgrade the Operator using the Helm CLI:
     ```
     helm chart export ${REGISTRY-URL} -d ${CHART_DIR}
     ```
-    Where `REGISTRY-URL` is the reference to the <%= vars.product_short %> Helm chart.
-The value of `REGISTRY-URL` has the following pattern:
+    Where `REGISTRY-URL` is the reference to the <%= vars.product_short %> Helm chart. The value of `REGISTRY-URL` has the following pattern:
 
     ```
     registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:VERSION-NUMBER-TAG
     ```
-    Where `VERSION-NUMBER-TAG` is the version of the Helm chart.
+    Where `VERSION-NUMBER-TAG` is the version of the Helm chart. This downloads a directory named `tanzu-sql-with-mysql-operator/` into your current working directory.
 
-    <br>This downloads a directory named `tanzu-sql-with-mysql-operator/` into your current working directory
-
-1. Go to where the new release has been downloaded and apply the new CRDs by running:
+1. In the location where the new release has been downloaded, apply the new CRDs by running:
 
     ```
     kubectl apply -f ./tanzu-sql-with-mysql-operator/crds/
@@ -101,4 +98,6 @@ The value of `REGISTRY-URL` has the following pattern:
 	rm ${CHART_DIR}
 	```
 
-1. After upgradeding the Operator, check the status of your existing instances and plan for an upgrade or an update. Review [Upgrading an Instance]() and [Updating an Instance Version](update-instance.html#update-instance). 
+1. Check the status of your existing instances, and plan for an upgrade or an update. 
+
+    Use the command `kubectl get mysqls` and review [Upgrading an Instance](upgrade-instance.html#upgrade-steps) and [Updating an Instance Version](update-instance.html#update-instance). 


### PR DESCRIPTION
Updating and upgrading the instances refreshed topics. 


Html render, starting the flow at the bottom of the Upgrade Operator topic:
https://docs-staging.vmware.com/en/VMware-Tanzu-SQL-with-MySQL-for-Kubernetes/wip_instance_upgrade/tanzu-mysql-k8s/GUID-upgrade-operator.html