### PR TITLE
Update property-reference-mysql.html.md.erb

### DIFF
--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -142,11 +142,11 @@ The name of the MySQL instance. Must be unique within a namespace. Cannot be mod
 
 ## <a id="spec"></a> Spec
 
-**`mysqlversion: <String>`**<br />
+**`mysqlVersion: <String>`**<br />
 **Optional**<br />
 **Default**: <latest MySQL release supported><br />
 The MySQL version that will be used for creating an instance. If the user does not specify a value, the latest supported version will be used as the default. For example, if the Tanzu MySQL Operator supports mysql-8.0.25, mysql-8.0.26, mysql-8.0.27, this value defaults to mysql-8.0.27.<br/>
-From Tanzu MySQL Operator 1.4.0 release, three MySQL versions are supported at any time. Only the permitted version strings are valid input for the field. Entries that do not match a supported version generate an error. Use `kubectl get mysqlVersion` to verify the MySQL versions of your Operator release.  <br />
+From Tanzu MySQL Operator 1.4.0 release, three MySQL versions are supported at any time. Only the permitted version strings are valid input for the field. Entries that do not match a supported version generate an error. Use `kubectl get mysqlversion` to verify the MySQL versions of your Operator release.  <br />
 Use the "floating version tag" `mysql-latest` to configure your instance to always upgrade to the latest MySQL version supported by future Operator upgrades.<br/>
 **Example**:<br/>
 `mysql-8.0.26`


### PR DESCRIPTION
mysqlVersion camelCase fixes

- Correct spec property name 'mysqlversion' to lower camelCase `mysqlVersion`
- flatten kubectl command to all lowercase: 'kubectl get mysqlversion' (all lower-case
  seems to be standard for kubectl, though it's case-insensitive so anything works technically)

Merge to...main, I guess.
