### PR TITLE
install/upgrade-operator: helm behavior clarifications

### DIFF
--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -468,3 +468,5 @@ Edit the Operator Configuration file:
 	```
 	rm ${CHART_DIR}
 	```
+
+    If you created an Operator Values Override file, it is recommended you save that file for reference during subsequent Operator upgrades. By default, Helm will re-apply those override values when you later `helm upgrade` your Operator, unless you perform the upgrade with other overrides or with the `--reset-values` flag. See <A HREF="https://helm.sh/docs/helm/helm_upgrade/">Helm Upgrade documentation</A> for details.

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -11,6 +11,10 @@ This topic describes how to upgrade the <%= vars.product_full %> Operator.
 To upgrade <%= vars.product_short %>, you must download the resources, and upgrade
 the <%= vars.product_short %> Operator using Helm.
 
+These instructions assume your Operator is installed in the Operator namespace `tanzu-mysql-for-kubernetes-system`
+as described in Operator Installation documentation. If your Operator is installed in a different  namespace,
+replace `tanzu-mysql-for-kubernetes-system` with that namespace in the below commands.
+
 <p class="note"><strong>IMPORTANT:</strong> From version 1.4.0, upgrading the Operator does not disrupt or upgrade the existing instances. Be advised that the owners of the instances might be encouraged to upgrade or update their instances. </p>
 
 1. Set the environment variable to enable OCI support in the Helm v3 client by running:
@@ -33,41 +37,45 @@ the <%= vars.product_short %> Operator using Helm.
 1. Verify that you have a running <%= vars.product_short %> Operator by running:
 
     ```
-    helm -n tanzu-mysql-for-kubernetes-system ls
+    helm ls -n tanzu-mysql-for-kubernetes-system
     ```
     For example:
 
     ``` 
-    helm -n tanzu-mysql-for-kubernetes-system ls
+    helm ls -n tanzu-mysql-for-kubernetes-system
     NAME                    NAMESPACE                               REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
-    tanzu-mysql-operator    tanzu-mysql-for-kubernetes-system       1               2021-04-01 12:15:07.16966 -0500 CDT     deployed        tanzu-sql-with-mysql-operator-1.0.0     1.0.0
+    tanzu-mysql-operator    tanzu-mysql-for-kubernetes-system       1               2022-03-11 12:15:07.16966 -0500 CDT     deployed        tanzu-sql-with-mysql-operator-1.3.0     1.3.0
     ```
 
-1.  Create a temporary directory to export the chart by running:
+1.  Create a temporary working directory to export the chart into by running:
 
 	```
-	CHART_DIR=$(mktemp -d /tmp/tanzu-mysql-operator-chart:${VERSION-NUMBER-TAG}.XXXXX)
+	CHART_DIR=$(mktemp -d /tmp/tanzu-mysql-operator-chart:1.4.0.XXXXX)
 	```
 
-1. Download the Helm chart to your current working directory on your local machine by running these commands:
+1. Download the Helm chart to your temporary working directory on your local machine by running these commands:
+
+	If you're using Helm CLI 3.6 and earlier:
 
     ```
-    helm chart pull ${REGISTRY-URL}
+    helm chart pull registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.4.0
     ```
     ```
-    helm chart export ${REGISTRY-URL} -d ${CHART_DIR}
+    helm chart export registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.4.0 -d ${CHART_DIR}
     ```
-    Where `REGISTRY-URL` is the reference to the <%= vars.product_short %> Helm chart. The value of `REGISTRY-URL` has the following pattern:
 
-    ```
-    registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:VERSION-NUMBER-TAG
-    ```
-    Where `VERSION-NUMBER-TAG` is the version of the Helm chart. This downloads a directory named `tanzu-sql-with-mysql-operator/` into your current working directory.
+
+	If you're using Helm CLI 3.7.1 and later:
+	```
+	helm pull oci://registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart \
+	  --version 1.4.0 --untar --untardir ${CHART_DIR}
+	```
+
 
 1. In the location where the new release has been downloaded, apply the new CRDs by running:
 
     ```
-    kubectl apply -f ./tanzu-sql-with-mysql-operator/crds/
+    kubectl apply -f ${CHART_DIR}/tanzu-sql-with-mysql-operator/crds/
     ```
 
     <p class="note">
@@ -77,20 +85,23 @@ the <%= vars.product_short %> Operator using Helm.
 1. Upgrade the Operator by running:
 
     ```
-    helm upgrade tanzu-sql-with-mysql-operator ./tanzu-sql-with-mysql-operator
+    helm upgrade tanzu-sql-with-mysql-operator ${CHART_DIR}/tanzu-sql-with-mysql-operator \
+      -n tanzu-mysql-for-kubernetes-system
     ```
 
     When you see `deployed` in the `STATUS` column, the <%= vars.product_short %>
     Helm chart has upgraded:
 
     ``` 
-    helm -n tanzu-mysql-for-kubernetes-system history tanzu-sql-with-mysql-operator
-    ```
+    helm history tanzu-sql-with-mysql-operator -n tanzu-mysql-for-kubernetes-system
+		```
     ```
     REVISION    UPDATED                     STATUS        CHART                                  APP VERSION    DESCRIPTION
     1           Thu Jan 14 17:47:53 2021    superseded    tanzu-sql-with-mysql-operator-1.0.0     1.0.0          Install complete
     2           Thu Jan 14 18:09:05 2021    deployed      tanzu-sql-with-mysql-operator-1.0.1     1.0.1          Upgrade complete
-    ``` 
+    ```
+
+  If your Operator was previously installed using an Operator Values Override file (or other command-line values overrides, then Helm will re-apply those override values to this upgrade, unless you perform the upgrade with other overrides or with the `--reset-values` flag. See <A HREF="https://helm.sh/docs/helm/helm_upgrade/">Helm Upgrade documentation</A> for details.
 
 1. Clean up the temporary directory if it is no longer needed with the exported chart by running:
 	```


### PR DESCRIPTION
install-operator.html.md.erb:
- Clarify rationale for saving overrides file

upgrade-operator.html.md.erb:
- Clarified assumption that "tanzu-mysql-for-kubernetes-system" is
  default-installed namespace, & to substitute user's own as needed
- Moved namespace designation to the end of each command:
  before: "helm -n tanzu-mysql-for-kubernetes-system ls"
  after:  "helm ls -n tanzu-mysql-for-kubernetes-system"
- Aligned assumptions & formatting with Postgres docs:
- Hard-coded Versions to the current/documented 1.4.0
  (removing use of $VERSION-NUMBER-TAG variable in
   user-facing instructions).
- Hard-coded registry to indicate standard registry.tanzu.vmware.com
  (Removing complex "here is how you might wire in your own registry"
  scenario, aligning with our own install and postgres docs)
- fixed "VERSION-NUMBER-TAG" references, replacing with
  hard-coded "1.4.0". (Some references were broken/unresolved, others
  were in written user instructions which added complexity to upgrade
  process.)
- Referenced ${CHART_DIR} as the consistent location of the exported
  chart throughout.
- Added warning about prior overrides being applied.

Authored-by: Kim Bassett <kbassett@vmware.com>

Name the branches to merge this change with or enter "None".
