### PR TITLE
Update MySQL versions for 1.6.0 release

### DIFF
--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -45,7 +45,7 @@ When you create a MySQL instance, the MySQL Operator also creates PVCs. The PVCs
 
 ### <a id="version"></a> Selecting the Tanzu MySQL Version
 
-The Tanzu MySQL Operator by default deploys the latest supported MySQL database version. Beginning with version 1.5.0, the Tanzu Operator supports four versions: mysql-8.0.25, mysql-8.0.26, mysql-8.0.27, and mysql-8.0.28. To view your Operator's available Tanzu MySQL versions, run the command:
+The Tanzu MySQL Operator by default deploys the latest supported MySQL database version. The Tanzu Operator supports four versions: mysql-8.0.26, mysql-8.0.27, mysql-8.0.28, and mysql-8.0.29. To view your Operator's available Tanzu MySQL versions, run the command:
 
 ```
 kubectl get mysqlversions
@@ -55,11 +55,11 @@ The command displays:
 
 ```
 NAME           DB VERSION
-mysql-8.0.25   8.0.25
 mysql-8.0.26   8.0.26
 mysql-8.0.27   8.0.27
 mysql-8.0.28   8.0.28
-mysql-latest   8.0.28
+mysql-8.0.29   8.0.29
+mysql-latest   8.0.29
 ```
 
 where:

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -41,6 +41,13 @@ The following table provides version and version-support information about <%= v
     <th>Compatible<br>Kubernetes Version</th>
   </tr>
   <tr>
+    <td>1.6.0</td>
+    <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
+    <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
+    <td>September 15th, 2022</td>
+    <td>1.19+</td>
+  </tr>
+  <tr>
     <td>1.5.0</td>
     <td>8.0.25<br/>8.0.26<br/>8.0.27<br/>8.0.28</td>
     <td>8.0.25<br/>8.0.26<br/>8.0.27<br/>8.0.28</td>

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -115,10 +115,10 @@ You can access and install <%=vars.product_name %> using two different methods:
 1.  Load the MySQL instance images to the Docker registry:
 
     ``` 
-    docker load -i ./images/tanzu-mysql-instance-8.0.25
     docker load -i ./images/tanzu-mysql-instance-8.0.26
     docker load -i ./images/tanzu-mysql-instance-8.0.27
     docker load -i ./images/tanzu-mysql-instance-8.0.28
+    docker load -i ./images/tanzu-mysql-instance-8.0.29
     ```
 
 1.  Load the MySQL Operator image to the Docker registry:
@@ -134,11 +134,11 @@ You can access and install <%=vars.product_name %> using two different methods:
     ```
 	```
 	   REPOSITORY                                                                  	       TAG       IMAGE ID       CREATED        SIZE
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.25    1.5.0     e8eb899f5df6   5 weeks ago    793MB
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.26    1.5.0     110f35a9006d   5 weeks ago    842MB
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.27    1.5.0     b2767c434c61   5 weeks ago    907MB
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.28    1.5.0     b2767c434c61   5 weeks ago    907MB
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator   	       1.5.0     8b46a4d26aa0   5 weeks ago    76.9MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.26    1.6.0     110f35a9006d   2 weeks ago    842MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.27    1.6.0     b2767c434c61   2 weeks ago    907MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.28    1.6.0     3j2h83j93msl   2 weeks ago    917MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.29    1.6.0     19j38fj20xk3   2 weeks ago    902MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator   	       1.6.0     8b46a4d26aa0   2 weeks ago    76.9MB
 	```
 
 1.  Push the Tanzu MySQL Docker images to the container registry of your choice. Set each image's project and image repo name, tag the images, and then push them using the Docker command `docker push`.
@@ -151,10 +151,6 @@ You can access and install <%=vars.product_name %> using two different methods:
     PROJECT=$(gcloud config list core/project --format='value(core.project)')
     REGISTRY="gcr.io/${PROJECT}"
 
-    INSTANCE_IMAGE_NAME="${REGISTRY}/tanzu-mysql-instance:$(cat ./images/tanzu-mysql-instance-8.0.25-tag)"
-    docker tag $(cat ./images/tanzu-mysql-instance-8.0.25-id) ${INSTANCE_IMAGE_NAME}
-    docker push ${INSTANCE_IMAGE_NAME}
-
     INSTANCE_IMAGE_NAME="${REGISTRY}/tanzu-mysql-instance:$(cat ./images/tanzu-mysql-instance-8.0.26-tag)"
     docker tag $(cat ./images/tanzu-mysql-instance-8.0.26-id) ${INSTANCE_IMAGE_NAME}
     docker push ${INSTANCE_IMAGE_NAME}
@@ -165,6 +161,10 @@ You can access and install <%=vars.product_name %> using two different methods:
 
     INSTANCE_IMAGE_NAME="${REGISTRY}/tanzu-mysql-instance:$(cat ./images/tanzu-mysql-instance-8.0.28-tag)"
     docker tag $(cat ./images/tanzu-mysql-instance-8.0.28-id) ${INSTANCE_IMAGE_NAME}
+    docker push ${INSTANCE_IMAGE_NAME}
+
+    INSTANCE_IMAGE_NAME="${REGISTRY}/tanzu-mysql-instance:$(cat ./images/tanzu-mysql-instance-8.0.29-tag)"
+    docker tag $(cat ./images/tanzu-mysql-instance-8.0.29-id) ${INSTANCE_IMAGE_NAME}
     docker push ${INSTANCE_IMAGE_NAME}
 
     OPERATOR_IMAGE_NAME="${REGISTRY}/tanzu-mysql-operator:$(cat ./images/tanzu-mysql-operator-tag)"

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -66,7 +66,7 @@ The <%= vars.product_short %> releases support the components listed below:
 
 This version of Tanzu MySQL is supported on the following platforms:
 
-- [VMware Tanzu Kubernetes Grid Integrated Edition](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid-Integrated-Edition/index.html) (TKGI), version 1.9.x - 1.12.x
+- [VMware Tanzu Kubernetes Grid Integrated Edition](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid-Integrated-Edition/index.html) (TKGI), version 1.12.x - 1.14.x
 - [VMware Tanzu Kubernetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html) (TKGm) on AWS, version 1.2.x - 1.4.x
 - Google Kubernetes Engine (GKE)
 - Amazon Elastic Kubernetes Service (EKS)

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -18,6 +18,11 @@ The <%= vars.product_short %> releases support the components listed below:
     <th>Percona XtraBackup</th>
   </tr>
   <tr>
+    <td>1.6.0</td>
+    <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
+    <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
+  </tr>
+  <tr>
     <td>1.5.0</td>
     <td>8.0.25<br/>8.0.26<br/>8.0.27<br/>8.0.28</td>
     <td>8.0.25<br/>8.0.26<br/>8.0.27<br/>8.0.28</td>
@@ -52,6 +57,32 @@ The <%= vars.product_short %> releases support the components listed below:
 <p class="note">
      <strong>IMPORTANT:</strong> VMware does not support deployments that have been modified by adding layers to the packaged Docker images, or deployments that reference images other than the VMware MySQL Operator. VMware does not support changing the contents of the deployed containers and pods in any way.
  </p>
+
+## <a id="1-6-0"></a>  Version 1.6.0
+
+**Release Date: September 15, 2022**
+
+### <a id="16_supported_platforms"></a> Supported Platforms
+
+This version of Tanzu MySQL is supported on the following platforms:
+
+- [VMware Tanzu Kubernetes Grid Integrated Edition](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid-Integrated-Edition/index.html) (TKGI), version 1.9.x - 1.12.x
+- [VMware Tanzu Kubernetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html) (TKGm) on AWS, version 1.2.x - 1.4.x
+- Google Kubernetes Engine (GKE)
+- Amazon Elastic Kubernetes Service (EKS)
+- Kubernetes version 1.19+
+
+Additional Kubernetes environments, such as Minikube, can be used for testing or demonstration purposes.
+
+### <a id="16_features"></a> Features
+
+* Tanzu MySQL Operator 1.6.0 supports four different MySQL versions:
+  - 8.0.26
+  - 8.0.27
+  - 8.0.28
+  - 8.0.29
+
+* Release 1.6.0 updates the VMware Tanzu Data Services package to version 1.4.0: `registry.tanzu.vmware.com/packages-for-vmware-tanzu-data-services/tds-packages:1.4.0`. The TDS package 1.4.0 includes both Tanzu MySQL and Tanzu Postgres releases. For more information on installing Tanzu MySQL using the Tanzu CLI, refer to [Installing using the Tanzu CLI](install-operator.html#installing-using-the-tanzu-cli).
 
 ## <a id="1-5-0"></a>  Version 1.5.0
 

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -33,11 +33,11 @@ After an Operator upgrade, instances created under an older Operator require rec
     
     ```
     NAME           DB VERSION
-    mysql-8.0.25   8.0.25
     mysql-8.0.26   8.0.26
     mysql-8.0.27   8.0.27
     mysql-8.0.28   8.0.28
-    mysql-latest   8.0.28
+    mysql-8.0.29   8.0.29
+    mysql-latest   8.0.29
     ```
     
     The list indicates the four distinct database versions the Operator supports. 


### PR DESCRIPTION
- I've removed 8.0.25 where needed
- I've added 8.0.29 where needed
- I've setup the basic release notes for 1.6.0. 

For now, I'm going with the assumption that MySQL will release after Postgres and TDS package will be 1.4.0. We can update this as we get closer to the ETA of September 15th.

I've also left the minimum Kubernetes version as 1.19. I don't think this is right but I'll verify and submit a PR for that.

Authored-by: Shaan Sapra <shsapra@vmware.com>
