### PR TITLE
Corrections from actually running the commands in the install and upgrade docs

### DIFF
--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -336,7 +336,7 @@ Create an Operator Values Override file:
     ``` 
     helm install --wait my-mysql-operator /tmp/tanzu-sql-with-mysql-operator/ \
       --values=operator-values-overrides.yaml \
-      --namespace=mysql-for-kubernetes-system \
+      --namespace=tanzu-mysql-for-kubernetes-system \
       --create-namespace
     ``` 
 
@@ -344,7 +344,7 @@ Create an Operator Values Override file:
     * `--wait` flag waits for the Operator deployment to complete before any image installation starts
     * `my-mysql-operator` is the custom name you provide for your MySQL Operator
     * `/tmp/tanzu-sql-with-mysql-operator/` is the location of the MySQL Operator helm chart
-    * `mysql-for-kubernetes-system` is the Operator namespace you created in [Create Operator Namespace and Secrets](#create-namespace-and-secrets)
+    * `tanzu-mysql-for-kubernetes-system` is the Operator namespace you created in [Create Operator Namespace and Secrets](#create-namespace-and-secrets)
     * `operator-values-overrides.yaml` is the overrides file with your custom values, as per [Review the Operator Values](#create-overrides)
 
     The command displays a message similar to:
@@ -387,12 +387,12 @@ Create an Operator Values Override file:
     You may also check the logs to confirm the Operator is running properly:
 
     ``` 
-    kubectl logs -l app=tanzu-mysql-operator
+    kubectl logs -n tanzu-mysql-for-kubernetes-system -l app.kubernetes.io/name=tanzu-sql-with-mysql-operator
     ``` 
     
 1. Clean up the temporary directory if you no longer need the exported chart:
 	```
-	rm ${CHART_DIR}
+	rm -rf ${CHART_DIR}
 	```
 
 ## <a id="tanzu_cli_install"></a> Installing using the Tanzu CLI

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -96,9 +96,12 @@ replace `tanzu-mysql-for-kubernetes-system` with that namespace in the below com
 
     ``` 
     helm history tanzu-sql-with-mysql-operator -n tanzu-mysql-for-kubernetes-system
-		```
+    ```
 
-  If your Operator was previously installed using an Operator Values Override file (or other command-line values overrides, then Helm will re-apply those override values to this upgrade, unless you perform the upgrade with other overrides or with the `--reset-values` flag. See <A HREF="https://helm.sh/docs/helm/helm_upgrade/">Helm Upgrade documentation</A> for details.
+  If your Operator was previously installed using an Operator Values Override file (or other command-line values
+  overrides), then Helm will re-apply those override values to this upgrade, unless you perform the upgrade with other
+  overrides or with the `--reset-values` flag.
+  See [Helm Upgrade documentation](https://helm.sh/docs/helm/helm_upgrade/) for details.
 
 1. Clean up the temporary directory if it is no longer needed with the exported chart by running:
 	```
@@ -109,4 +112,4 @@ replace `tanzu-mysql-for-kubernetes-system` with that namespace in the below com
 
 Check the status of your existing instances, and plan for an upgrade or an update. 
 
-Use the command `kubectl get mysqls` and review [List Instance Versions](upgrade-instance.html#upgrade-steps), [Upgrade an Instance](upgrade-instance.html#upgrade-steps) and [Updating an Instance](update-instance.html#update-instance). 
+Use the command `kubectl get mysqls` and review [List Instance Versions](upgrade-instance.html#upgrade-steps), [Upgrade an Instance](upgrade-instance.html#upgrade-steps) and [Updating an Instance](update-instance.html#update-instance).


### PR DESCRIPTION
- Use consistent namespace for the operator
- Fix indentation of a verbatim block so the following note is legible
- Use markdown link over <a> tag.
- Specify namespace and correct label in `kubectl logs` command

Co-authored-by: David Sharp <dsharp@vmware.com>
Co-authored-by: Shaan Sapra <shsapra@vmware.com>

Name the branches to merge this change with or enter "None": 1.6
