### PR TITLE
Pr/v1.6.1 move cabundle

### DIFF
--- a/backup-restore.html.md.erb
+++ b/backup-restore.html.md.erb
@@ -74,7 +74,7 @@ To create a MySQLBackupLocation resource:
     For example:
 
     ``` 
-    cp ~/Downloads/tanzu-mysql-deployment-templates-1.6.0/samples/backuplocation.yaml testbackuplocation.yaml
+    cp ~/Downloads/tanzu-mysql-deployment-templates-1.6.1/samples/backuplocation.yaml testbackuplocation.yaml
     ``` 
 
 2. Edit the file with the configuration details of your external blobstore. 
@@ -140,7 +140,7 @@ To set a schedule for automatic backups, create a MySQLBackupSchedule resource:
     For example:
 
     ``` 
-    cp ~/Downloads/tanzu-mysql-deployment-templates-1.6.0/samples/backupschedule.yaml testbackupschedule.yaml
+    cp ~/Downloads/tanzu-mysql-deployment-templates-1.6.1/samples/backupschedule.yaml testbackupschedule.yaml
     ``` 
 
 2. Edit the file with the name of the MySQLBackupLocation resource
@@ -234,7 +234,7 @@ To take a backup:
     For example:
 
     ``` 
-    cp ~/Downloads/tanzu-mysql-deployment-templates-1.6.0/samples/backup.yaml testbackup.yaml
+    cp ~/Downloads/tanzu-mysql-deployment-templates-1.6.1/samples/backup.yaml testbackup.yaml
     ``` 
 
 3. Edit the file.
@@ -399,7 +399,7 @@ To restore from a backup:
     For example:
 
     ``` 
-    cp ~/Downloads/tanzu-mysql-deployment-templates-1.6.0/samples/restore.yaml testrestore.yaml
+    cp ~/Downloads/tanzu-mysql-deployment-templates-1.6.1/samples/restore.yaml testrestore.yaml
     ``` 
 
 

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -20,13 +20,13 @@ To access the templates:
 
 1. Log in to [<%= vars.product_network %>](https://network.pivotal.io) and visit the [Tanzu MySQL](https://network.pivotal.io/products/tanzu-mysql-for-kubernetes/) product page.
 
-1. Select **VMware Tanzu SQL with MySQL for Kubernetes v1.6.0** and download the .tgz archive file to your local machine.<br/>
+1. Select **VMware Tanzu SQL with MySQL for Kubernetes v1.6.1** and download the .tgz archive file to your local machine.<br/>
    
    <p class="note">
        <strong>Note:</strong> You do not need to download the <b>Artifact References</b> from the Tanzu MySQL for Kubernetes product page.
     </p>
 
-1. Expand the downloaded .tgz file. Open the directory `tanzu-mysql-for-kubernetes-1.6.0`. The templates are located in the `samples` subdirectory.
+1. Expand the downloaded .tgz file. Open the directory `tanzu-mysql-for-kubernetes-1.6.1`. The templates are located in the `samples` subdirectory.
 
 The templates include the following:
 
@@ -66,7 +66,7 @@ mysql-latest   8.0.29
 ```
 
 where:
-- `NAME` denotes the Tanzu MySQL version. The special Tanzu MySQL version named `mysql-latest` runs the latest Operator-supported MySQL version (for example, in 1.6.0 that is 8.0.29). It also configures the instance to automatically upgrade its MySQL version whenever any future Operator upgrades add support for newer MySQL versions. For more details see [Property Reference for MySQL Resource](property-reference-mysql.html#spec).
+- `NAME` denotes the Tanzu MySQL version. The special Tanzu MySQL version named `mysql-latest` runs the latest Operator-supported MySQL version (for example, in 1.6.1 that is 8.0.29). It also configures the instance to automatically upgrade its MySQL version whenever any future Operator upgrades add support for newer MySQL versions. For more details see [Property Reference for MySQL Resource](property-reference-mysql.html#spec).
 - `DB VERSION` displays the Percona MySQL version an instance runs when that Tanzu MySQL version is named in the instance's spec. 
 
 Note which value in the `DB VERSION` column you wish to deploy with your instance, if different than the default. 
@@ -170,7 +170,7 @@ To create a MySQL instance:
     ```
     ```
     NAME           READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION
-    mysql-sample   true    Running   162m   1.6.0           8.0.29       NoUpdateRequired
+    mysql-sample   true    Running   162m   1.6.1           8.0.29       NoUpdateRequired
     ``` 
 8. Review [Configuring TLS for MySQL Instances](configure-tls.html) if you need to configure a custom `ClusterIssuer`. By default, the MySQL instances created by Tanzu Operator 1.2.0 (and later) use TLS certificates provided by the cert-manager `ClusterIssuer`, using a self-signed certificate authority (CA). 
 

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -41,7 +41,7 @@ The following table provides version and version-support information about <%= v
     <th>Compatible<br>Kubernetes Version</th>
   </tr>
   <tr>
-    <td>1.6.0</td>
+    <td>1.6.1</td>
     <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
     <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
     <td>September 15th, 2022</td>

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -79,15 +79,15 @@ You can access and install <%=vars.product_name %> using two different methods:
     If you're using Helm CLI 3.6 and earlier:
 
     ```
-    helm chart pull registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.6.0
+    helm chart pull registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.6.1
     ```
     ```
-    helm chart export registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.6.0 --destination=/tmp/
+    helm chart export registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.6.1 --destination=/tmp/
     ```
 
     If you're using Helm CLI 3.7.1 and later:
     ```
-    helm pull oci://registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart --version 1.6.0 --untar --untardir /tmp
+    helm pull oci://registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart --version 1.6.1 --untar --untardir /tmp
     ```
 
 #### <a id="install-via-tar"></a> Setup the Tanzu Operator via a Downloaded Archive File
@@ -103,7 +103,7 @@ You can access and install <%=vars.product_name %> using two different methods:
     tar xzf tanzu-mysql-for-kubernetes-<version>.tgz
     ``` 
 
-    This command unpacks the distribution into a new directory named `tanzu-mysql-for-kubernetes-<version>`, for example `tanzu-mysql-for-kubernetes-1.6.0`.
+    This command unpacks the distribution into a new directory named `tanzu-mysql-for-kubernetes-<version>`, for example `tanzu-mysql-for-kubernetes-1.6.1`.
 
 1.  Change to the new `tanzu-mysql-for-kubernetes-<version>` directory. For example:
 
@@ -134,11 +134,11 @@ You can access and install <%=vars.product_name %> using two different methods:
     ```
 	```
 	   REPOSITORY                                                                  	       TAG       IMAGE ID       CREATED        SIZE
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.26    1.6.0     110f35a9006d   2 weeks ago    842MB
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.27    1.6.0     b2767c434c61   2 weeks ago    907MB
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.28    1.6.0     3j2h83j93msl   2 weeks ago    917MB
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.29    1.6.0     19j38fj20xk3   2 weeks ago    902MB
-	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator   	       1.6.0     8b46a4d26aa0   2 weeks ago    76.9MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.26    1.6.1     110f35a9006d   2 weeks ago    842MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.27    1.6.1     b2767c434c61   2 weeks ago    907MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.28    1.6.1     3j2h83j93msl   2 weeks ago    917MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-instance-8.0.29    1.6.1     19j38fj20xk3   2 weeks ago    902MB
+	   registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator   	       1.6.1     8b46a4d26aa0   2 weeks ago    76.9MB
 	```
 
 1.  Push the Tanzu MySQL Docker images to the container registry of your choice. Set each image's project and image repo name, tag the images, and then push them using the Docker command `docker push`.
@@ -265,7 +265,7 @@ Create an Operator Values Override file:
     ```
     ---
     imagePullSecretName: tanzu-image-registry
-    operatorImage: registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.6.0
+    operatorImage: registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator:1.6.1
     registry: "registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/"
     resources: {}
     certManagerClusterIssuerName: ""
@@ -431,7 +431,7 @@ To relocate images from the VMware Tanzu Network registry to a private registry:
    where:
     - `MY-REGISTRY` is your own image registry
     - `TARGET-REPOSITORY` is your target repository
-    - `TDS-VERSION` is the tag for the image bundle (e.g `1.2.0`). Each Tanzu MySQL release corresponds to a TDS package version. For instance, MySQL Operator version 1.6.0 is part of TDS version 1.3.0. Insert the right version for your Tanzu MySQL Operator release.
+    - `TDS-VERSION` is the tag for the image bundle (e.g `1.2.0`). Each Tanzu MySQL release corresponds to a TDS package version. For instance, MySQL Operator version 1.6.1 is part of TDS version 1.3.0. Insert the right version for your Tanzu MySQL Operator release.
 
 ### <a id="secret_cli"></a> Create a Kubernetes Secret
 
@@ -486,17 +486,17 @@ tanzu package available list -n <NAMESPACE>
 ```
 - Retrieving available packages...
   NAME                                      DISPLAY-NAME                                   SHORT-DESCRIPTION                   LATEST-VERSION
-  mysql-operator.with.sql.tanzu.vmware.com  VMware Tanzu SQL with MySQL for Kubernetes     Kubernetes Operator for MySQL       1.6.0
+  mysql-operator.with.sql.tanzu.vmware.com  VMware Tanzu SQL with MySQL for Kubernetes     Kubernetes Operator for MySQL       1.6.1
   postgres-operator.sql.tanzu.vmware.com    VMware Tanzu SQL with Postgres for Kubernetes  Kubernetes Operator for PostgreSQL  1.8.0
 ```
 
 Check the values for the MySQL Operator package:
 
 ```
-tanzu package available get mysql-operator.with.sql.tanzu.vmware.com/1.6.0 --values-schema -n <NAMESPACE>
+tanzu package available get mysql-operator.with.sql.tanzu.vmware.com/1.6.1 --values-schema -n <NAMESPACE>
 ```
 ```
-- Retrieving package details for mysql-operator.with.sql.tanzu.vmware.com/1.6.0...
+- Retrieving package details for mysql-operator.with.sql.tanzu.vmware.com/1.6.1...
   KEY                           DEFAULT                                                     TYPE    DESCRIPTION
   certManagerClusterIssuerName  tanzu-sql-with-mysql-operator-ca-certificate-clusterissuer  string  A cert-manager based clusterissuer used to sign mysql certificates using a custom certificate authority
   imagePullSecretName           tanzu-image-registry                                        string  Reference to a secret in the same namespace as the operator to use for pulling any of the images used by the operator.
@@ -524,7 +524,7 @@ resources:
    Install the MySQL operator package, using the overrides file you created:
 
     ```
-    tanzu package install <PACKAGE-NAME> --package-name mysql-operator.with.sql.tanzu.vmware.com --version 1.6.0 -f <YOUR-OVERRIDES-FILE-PATH> -n <NAMESPACE>
+    tanzu package install <PACKAGE-NAME> --package-name mysql-operator.with.sql.tanzu.vmware.com --version 1.6.1 -f <YOUR-OVERRIDES-FILE-PATH> -n <NAMESPACE>
     ```
    where:
 
@@ -557,7 +557,7 @@ resources:
     ```
     - Retrieving installed packages...
       NAME                  PACKAGE-NAME                              PACKAGE-VERSION  STATUS
-      tanzu-mysql-operator  mysql-operator.with.sql.tanzu.vmware.com  1.6.0            Reconcile succeeded
+      tanzu-mysql-operator  mysql-operator.with.sql.tanzu.vmware.com  1.6.1            Reconcile succeeded
     ```
 
    A service account is created so that the `kapp-controller` can create cluster-scope objects such as CustomResourceDefinitions, and so it will have permissions to create     objects on any namespace. This service account is different than the service account for the MySQL operator to manage other Kubernetes resources (statefulsets, secrets, etc...)

--- a/property-reference-backup-restore.html.md.erb
+++ b/property-reference-backup-restore.html.md.erb
@@ -45,14 +45,6 @@ The table below explains the properties that can be set for the MySQLBackupLocat
   <td>Yes</td>
 </tr>
 <tr>
-  <td>spec.storage.caBundle</td>
-  <td>String</td>
-  <td><em>n/a</em></td>
-  <td>The PEM encoded CA bundle, which will be used to validate the storage endpoint TLS certificate.</td>
-  <td></td>
-  <td>No</td>
-</tr>
-<tr>
   <td>spec.storage.s3.bucket</td>
   <td>String</td>
   <td><em>n/a</em></td>
@@ -89,6 +81,15 @@ The table below explains the properties that can be set for the MySQLBackupLocat
   <td><code>http://minio.default:9000</code></td>
   <td>No</td>
 </tr>
+<tr>
+  <td>spec.storage.s3.caBundle</td>
+  <td>String</td>
+  <td><em>n/a</em></td>
+  <td>The PEM encoded CA bundle, which will be used to validate the storage endpoint TLS certificate.</td>
+  <td></td>
+  <td>No</td>
+</tr>
+<tr>
   <td>spec.storage.s3.forcePathStyle</td>
   <td>boolean</td><td>false</td>
   <td><code>true</code> forces the use of path-style S3 URLs for compatibility.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -23,6 +23,11 @@ The <%= vars.product_short %> releases support the components listed below:
     <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
   </tr>
   <tr>
+    <td>1.6.0 (RETRACTED)</td>
+    <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
+    <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
+  </tr>
+  <tr>
     <td>1.5.0</td>
     <td>8.0.25<br/>8.0.26<br/>8.0.27<br/>8.0.28</td>
     <td>8.0.25<br/>8.0.26<br/>8.0.27<br/>8.0.28</td>
@@ -60,6 +65,17 @@ The <%= vars.product_short %> releases support the components listed below:
 
 ## <a id="1-6-1"></a>  Version 1.6.1
 
+**Release Date: September 26th, 2022**
+
+Release 1.6.1 matches 1.6.0, but adds the following change:
+
+### <a id=16_changes></a> Changes
+
+* This release changes the field `spec.storage.caBundle` to `spec.storage.s3.caBundle`, to create the ability to configure a CA bundle for storage endpoints using custom TLS certificates. For details, refer to [Tanzu MySQL Property Reference](./property-reference-backup-restore.html).
+
+
+## <a id="1-6-0"></a>  Version 1.6.0 (RETRACTED)
+
 **Release Date: September 21st, 2022**
 
 ### <a id="16_supported_platforms"></a> Supported Platforms
@@ -76,15 +92,15 @@ Additional Kubernetes environments, such as Minikube, can be used for testing or
 
 ### <a id="16_features"></a> Features
 
-* Tanzu MySQL Operator 1.6.1 supports four different MySQL versions:
+* Tanzu MySQL Operator 1.6.0 supports four different MySQL versions:
   - 8.0.26
   - 8.0.27
   - 8.0.28
   - 8.0.29
 
-* Release 1.6.1 is included in the VMware Tanzu Data Services package version 1.4.0: `registry.tanzu.vmware.com/packages-for-vmware-tanzu-data-services/tds-packages:1.4.0`. For more information on installing Tanzu MySQL using the Tanzu CLI, refer to [Installing using the Tanzu CLI](install-operator.html#installing-using-the-tanzu-cli).
+* Release 1.6.0 is included in the VMware Tanzu Data Services package version 1.3.0: `registry.tanzu.vmware.com/packages-for-vmware-tanzu-data-services/tds-packages:1.3.0`. For more information on installing Tanzu MySQL using the Tanzu CLI, refer to [Installing using the Tanzu CLI](install-operator.html#installing-using-the-tanzu-cli).
 
-* This release adds the field `spec.storage.s3.caBundle`, to create the ability to configure a CA bundle for storage endpoints using custom TLS certificates. For details, refer to [Tanzu MySQL Property Reference](./property-reference-backup-restore.html).
+* This release adds the field `spec.storage.caBundle`, to create the ability to configure a CA bundle for storage endpoints using custom TLS certificates. For details, refer to [Tanzu MySQL Property Reference](./property-reference-backup-restore.html). 
 
 ### <a id=16_changes></a> Changes
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -18,7 +18,7 @@ The <%= vars.product_short %> releases support the components listed below:
     <th>Percona XtraBackup</th>
   </tr>
   <tr>
-    <td>1.6.0</td>
+    <td>1.6.1</td>
     <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
     <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
   </tr>
@@ -58,7 +58,7 @@ The <%= vars.product_short %> releases support the components listed below:
      <strong>IMPORTANT:</strong> VMware does not support deployments that have been modified by adding layers to the packaged Docker images, or deployments that reference images other than the VMware MySQL Operator. VMware does not support changing the contents of the deployed containers and pods in any way.
  </p>
 
-## <a id="1-6-0"></a>  Version 1.6.0
+## <a id="1-6-1"></a>  Version 1.6.1
 
 **Release Date: September 21st, 2022**
 
@@ -76,13 +76,13 @@ Additional Kubernetes environments, such as Minikube, can be used for testing or
 
 ### <a id="16_features"></a> Features
 
-* Tanzu MySQL Operator 1.6.0 supports four different MySQL versions:
+* Tanzu MySQL Operator 1.6.1 supports four different MySQL versions:
   - 8.0.26
   - 8.0.27
   - 8.0.28
   - 8.0.29
 
-* Release 1.6.0 is included in the VMware Tanzu Data Services package version 1.3.0: `registry.tanzu.vmware.com/packages-for-vmware-tanzu-data-services/tds-packages:1.3.0`. For more information on installing Tanzu MySQL using the Tanzu CLI, refer to [Installing using the Tanzu CLI](install-operator.html#installing-using-the-tanzu-cli).
+* Release 1.6.1 is included in the VMware Tanzu Data Services package version 1.4.0: `registry.tanzu.vmware.com/packages-for-vmware-tanzu-data-services/tds-packages:1.4.0`. For more information on installing Tanzu MySQL using the Tanzu CLI, refer to [Installing using the Tanzu CLI](install-operator.html#installing-using-the-tanzu-cli).
 
 * This release adds the field `spec.storage.caBundle`, to create the ability to configure a CA bundle for storage endpoints using custom TLS certificates. For details, refer to [Tanzu MySQL Property Reference](./property-reference-backup-restore.html). 
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -84,7 +84,7 @@ Additional Kubernetes environments, such as Minikube, can be used for testing or
 
 * Release 1.6.1 is included in the VMware Tanzu Data Services package version 1.4.0: `registry.tanzu.vmware.com/packages-for-vmware-tanzu-data-services/tds-packages:1.4.0`. For more information on installing Tanzu MySQL using the Tanzu CLI, refer to [Installing using the Tanzu CLI](install-operator.html#installing-using-the-tanzu-cli).
 
-* This release adds the field `spec.storage.caBundle`, to create the ability to configure a CA bundle for storage endpoints using custom TLS certificates. For details, refer to [Tanzu MySQL Property Reference](./property-reference-backup-restore.html). 
+* This release adds the field `spec.storage.s3.caBundle`, to create the ability to configure a CA bundle for storage endpoints using custom TLS certificates. For details, refer to [Tanzu MySQL Property Reference](./property-reference-backup-restore.html).
 
 ### <a id=16_changes></a> Changes
 

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -51,11 +51,11 @@ After an Operator upgrade, instances created under an older Tanzu MySQL Operator
     
     ```
     NAME           READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS      USER ACTION
-    mysql-sample   true    Running   6m5s   1.6.0           8.0.29       NoUpdateRequired
+    mysql-sample   true    Running   6m5s   1.6.1           8.0.29       NoUpdateRequired
  
     NAME           READY   STATUS    AGE    TANZU VERSION   DB VERSION   UPDATE STATUS       USER ACTION
          
-    mysql-sample   true    Running   6m5s   1.6.0           8.0.29       NoUpdateRequired
+    mysql-sample   true    Running   6m5s   1.6.1           8.0.29       NoUpdateRequired
     DBUPDONC-9     true    Running   20d    1.5.0           8.0.26       UpdateRequired      Annotate “mysql.with.sql.tanzu.vmware.com/update=once”
     instance-10    true    Running   41m    1.4.0           8.0.25       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version
     instance-8     true    Running   21d    1.3.0           8.0.25       DBUpgradeRequired   Set spec.mysqlVersion.name to a supported DB version 

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -46,13 +46,13 @@ replace `tanzu-mysql-for-kubernetes-system` with that namespace in the below com
     ```
     ```
     NAME                    NAMESPACE                               REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
-    tanzu-mysql-operator    tanzu-mysql-for-kubernetes-system       1               2022-09-11 12:15:07.16966 -0500 CDT     deployed        tanzu-sql-with-mysql-operator-1.6.0     1.6.0
+    tanzu-mysql-operator    tanzu-mysql-for-kubernetes-system       1               2022-09-11 12:15:07.16966 -0500 CDT     deployed        tanzu-sql-with-mysql-operator-1.6.1     1.6.0
     ```
 
 1.  Create a temporary working directory to export the chart into by running:
 
 	```
-	CHART_DIR=$(mktemp -d /tmp/tanzu-mysql-operator-chart:1.6.0.XXXXX)
+	CHART_DIR=$(mktemp -d /tmp/tanzu-mysql-operator-chart:1.6.1.XXXXX)
 	```
 
 1. Download the Helm chart to your temporary working directory on your local machine by running these commands:
@@ -60,10 +60,10 @@ replace `tanzu-mysql-for-kubernetes-system` with that namespace in the below com
 	  If you're using Helm CLI 3.6 and earlier:
 
     ```
-    helm chart pull registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.6.0
+    helm chart pull registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.6.1
     ```
     ```
-    helm chart export registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.6.0 -d ${CHART_DIR}
+    helm chart export registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/tanzu-mysql-operator-chart:1.6.1 -d ${CHART_DIR}
     ```
 
 


### PR DESCRIPTION
We're quickly following up 1.6.0 with 1.6.1 to fix a mistake where the new "caBundle" field was put in the wrong place. We plan to pull 1.6.0 off of tanzunet, so I updated all references to 1.6.0 to 1.6.1.

Name the branches to merge this change with or enter "None".  1.6
