### PR TITLE
Add support for mysql 8.0.31 and remove support for mysql 8.0.26 [1.7.0 Release]

### DIFF
--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -56,7 +56,9 @@ When you create a MySQL instance, the MySQL Operator also creates PVCs. The PVCs
 
 ### <a id="version"></a> Selecting the Tanzu MySQL Version
 
-The Tanzu MySQL Operator by default deploys the latest supported MySQL database version. The Tanzu Operator supports four versions: mysql-8.0.26, mysql-8.0.27, mysql-8.0.28, and mysql-8.0.29. To view your Operator's available Tanzu MySQL versions, run the command:
+The Tanzu MySQL Operator by default deploys the latest supported MySQL database version. The Tanzu Operator supports
+four versions: mysql-8.0.27, mysql-8.0.28, mysql-8.0.29, and mysql-8.0.30. To view your Operator's available Tanzu MySQL
+versions, run the command:
 
 ```
 kubectl get mysqlversions
@@ -66,11 +68,11 @@ The command displays:
 
 ```
 NAME           DB VERSION
-mysql-8.0.26   8.0.26
 mysql-8.0.27   8.0.27
 mysql-8.0.28   8.0.28
 mysql-8.0.29   8.0.29
-mysql-latest   8.0.29
+mysql-8.0.30   8.0.30
+mysql-latest   8.0.30
 ```
 
 where:
@@ -142,7 +144,7 @@ To create a MySQL instance:
     
     #### Specify the MySQL Version
       mysqlVersion:
-        name: mysql-8.0.26
+        name: mysql-8.0.30
     ...
     
     ```

--- a/create-delete-mysql.html.md.erb
+++ b/create-delete-mysql.html.md.erb
@@ -57,7 +57,7 @@ When you create a MySQL instance, the MySQL Operator also creates PVCs. The PVCs
 ### <a id="version"></a> Selecting the Tanzu MySQL Version
 
 The Tanzu MySQL Operator by default deploys the latest supported MySQL database version. The Tanzu Operator supports
-four versions: mysql-8.0.27, mysql-8.0.28, mysql-8.0.29, and mysql-8.0.30. To view your Operator's available Tanzu MySQL
+four versions: mysql-8.0.27, mysql-8.0.28, mysql-8.0.29, and mysql-8.0.31. To view your Operator's available Tanzu MySQL
 versions, run the command:
 
 ```
@@ -71,8 +71,8 @@ NAME           DB VERSION
 mysql-8.0.27   8.0.27
 mysql-8.0.28   8.0.28
 mysql-8.0.29   8.0.29
-mysql-8.0.30   8.0.30
-mysql-latest   8.0.30
+mysql-8.0.31   8.0.31
+mysql-latest   8.0.31
 ```
 
 where:
@@ -144,7 +144,7 @@ To create a MySQL instance:
     
     #### Specify the MySQL Version
       mysqlVersion:
-        name: mysql-8.0.30
+        name: mysql-8.0.31
     ...
     
     ```

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -41,6 +41,13 @@ The following table provides version and version-support information about <%= v
     <th>Compatible<br>Kubernetes Version</th>
   </tr>
   <tr>
+    <td>1.7.0</td>
+    <td>8.0.27<br/>8.0.28<br/>8.0.29<br/>8.0.30</td>
+    <td>8.0.27<br/>8.0.28<br/>8.0.29<br/>8.0.30</td>
+    <td>TBD</td>
+    <td>1.21+</td>
+  </tr>
+  <tr>
     <td>1.6.2</td>
     <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>
     <td>8.0.26<br/>8.0.27<br/>8.0.28<br/>8.0.29</td>

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -42,8 +42,8 @@ The following table provides version and version-support information about <%= v
   </tr>
   <tr>
     <td>1.7.0</td>
-    <td>8.0.27<br/>8.0.28<br/>8.0.29<br/>8.0.30</td>
-    <td>8.0.27<br/>8.0.28<br/>8.0.29<br/>8.0.30</td>
+    <td>8.0.27<br/>8.0.28<br/>8.0.29<br/>8.0.31</td>
+    <td>8.0.27<br/>8.0.28<br/>8.0.29<br/>8.0.31</td>
     <td>TBD</td>
     <td>1.21+</td>
   </tr>

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -162,7 +162,7 @@ and upgrade to the latest supported MySQL version for that Operator.
 **Optional**<br />
 **Default**: 1Gi<br />
 The size of the persistent volume claims (PVCs) for MySQL instance Pods. Specify a suffix for the units (for example:
-100G, 1T). After being set, cannot be reduced, but can be increased. For information about allowed size units, see
+100G, 1T). After being set, cannot be reduced, but can be increased. For information about allowed size units, see the
 discussion about resource quantities in
 the [The Kubernetes resource model](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/resources.md)
 in the community GitHub repository.<br />

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -154,7 +154,8 @@ versions of your Operator release.  <br />
 Use the "floating version tag" `mysql-latest` to configure your instance to always upgrade to the latest MySQL version
 supported by future Operator upgrades.<br/>
 **Example**: `mysql-8.0.31`<br/>
-**WARNING**: After an Operator upgrade, instances with `mysqlVersion.name` as`mysql-latest` will automatically reboot
+
+> **Caution** After an Operator upgrade, instances with `mysqlVersion.name` as `mysql-latest` will automatically reboot
 and upgrade to the latest supported MySQL version for that Operator.
 
 **`storageSize: <Quantity>`**<br />

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -15,7 +15,7 @@ spec:
 
 #### Specify the MySQL Version
 #  mysqlVersion:
-#    name: mysql-8.0.30
+#    name: mysql-8.0.31
 
 #### Set the storage size for the database persistent storage volume
 #  storageSize: 1Gi
@@ -147,13 +147,13 @@ The name of the MySQL instance. Must be unique within a namespace. Cannot be mod
 **Default**: <latest MySQL release supported><br />
 The MySQL version that will be used for creating an instance. If the user does not specify a value, the latest supported
 version will be used as the default. For example, if the Tanzu MySQL Operator supports mysql-8.0.27, mysql-8.0.28,
-mysql-8.0.29, and mysql-8.0.30 this value defaults to mysql-8.0.29.<br/>
+mysql-8.0.29, and mysql-8.0.31 this value defaults to mysql-8.0.31.<br/>
 Each Operator release supports several MySQL versions. Only the permitted version strings are valid input for the field.
 Entries that do not match a supported version generate an error. Use `kubectl get mysqlversion` to verify the MySQL
 versions of your Operator release.  <br />
 Use the "floating version tag" `mysql-latest` to configure your instance to always upgrade to the latest MySQL version
 supported by future Operator upgrades.<br/>
-**Example**: `mysql-8.0.30`<br/>
+**Example**: `mysql-8.0.31`<br/>
 **WARNING**: After an Operator upgrade, instances with `mysqlVersion.name` as`mysql-latest` will automatically reboot
 and upgrade to the latest supported MySQL version for that Operator.
 

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -15,7 +15,7 @@ spec:
 
 #### Specify the MySQL Version
 #  mysqlVersion:
-#    name: mysql-8.0.26
+#    name: mysql-8.0.30
 
 #### Set the storage size for the database persistent storage volume
 #  storageSize: 1Gi
@@ -145,16 +145,26 @@ The name of the MySQL instance. Must be unique within a namespace. Cannot be mod
 **`mysqlVersion: <String>`**<br />
 **Optional**<br />
 **Default**: <latest MySQL release supported><br />
-The MySQL version that will be used for creating an instance. If the user does not specify a value, the latest supported version will be used as the default. For example, if the Tanzu MySQL Operator supports mysql-8.0.26, mysql-8.0.27, mysql-8.0.28 and mysql-8.0.29, this value defaults to mysql-8.0.29.<br/>
-Each Operator release supports several MySQL versions. Only the permitted version strings are valid input for the field. Entries that do not match a supported version generate an error. Use `kubectl get mysqlversion` to verify the MySQL versions of your Operator release.  <br />
-Use the "floating version tag" `mysql-latest` to configure your instance to always upgrade to the latest MySQL version supported by future Operator upgrades.<br/>
-**Example**: `mysql-8.0.26`<br/>
-**WARNING**: After an Operator upgrade, instances with `mysqlVersion.name` as`mysql-latest` will automatically reboot and upgrade to the latest supported MySQL version for that Operator. 
-  
+The MySQL version that will be used for creating an instance. If the user does not specify a value, the latest supported
+version will be used as the default. For example, if the Tanzu MySQL Operator supports mysql-8.0.27, mysql-8.0.28,
+mysql-8.0.29, and mysql-8.0.30 this value defaults to mysql-8.0.29.<br/>
+Each Operator release supports several MySQL versions. Only the permitted version strings are valid input for the field.
+Entries that do not match a supported version generate an error. Use `kubectl get mysqlversion` to verify the MySQL
+versions of your Operator release.  <br />
+Use the "floating version tag" `mysql-latest` to configure your instance to always upgrade to the latest MySQL version
+supported by future Operator upgrades.<br/>
+**Example**: `mysql-8.0.30`<br/>
+**WARNING**: After an Operator upgrade, instances with `mysqlVersion.name` as`mysql-latest` will automatically reboot
+and upgrade to the latest supported MySQL version for that Operator.
+
 **`storageSize: <Quantity>`**<br />
 **Optional**<br />
 **Default**: 1Gi<br />
-The size of the persistent volume claims (PVCs) for MySQL instance Pods. Specify a suffix for the units (for example: 100G, 1T). After being set, cannot be reduced, but can be increased. For information about allowed size units, see discussion about resource quantities in the [The Kubernetes resource model](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/resources.md) in the community GitHub repository.<br />
+The size of the persistent volume claims (PVCs) for MySQL instance Pods. Specify a suffix for the units (for example:
+100G, 1T). After being set, cannot be reduced, but can be increased. For information about allowed size units, see
+discussion about resource quantities in
+the [The Kubernetes resource model](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/resources.md)
+in the community GitHub repository.<br />
 **Example**: 50Gi
 
 **`imagePullSecretName: <string>`**<br />

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -33,11 +33,11 @@ After an Operator upgrade, instances created under an older Tanzu MySQL Operator
     
     ```
     NAME           DB VERSION
-    mysql-8.0.26   8.0.26
     mysql-8.0.27   8.0.27
     mysql-8.0.28   8.0.28
     mysql-8.0.29   8.0.29
-    mysql-latest   8.0.29
+    mysql-8.0.30   8.0.30    
+    mysql-latest   8.0.30
     ```
     
     The list indicates the four distinct database versions the Operator supports. 

--- a/update-instance.html.md.erb
+++ b/update-instance.html.md.erb
@@ -36,8 +36,8 @@ After an Operator upgrade, instances created under an older Tanzu MySQL Operator
     mysql-8.0.27   8.0.27
     mysql-8.0.28   8.0.28
     mysql-8.0.29   8.0.29
-    mysql-8.0.30   8.0.30    
-    mysql-latest   8.0.30
+    mysql-8.0.31   8.0.31
+    mysql-latest   8.0.31
     ```
     
     The list indicates the four distinct database versions the Operator supports. 

--- a/upgrade-instance.html.md.erb
+++ b/upgrade-instance.html.md.erb
@@ -34,11 +34,11 @@ Depending on the Operator version, the command displays an ouput similar to:
 
 ```
 NAME           DB VERSION
-mysql-8.0.26   8.0.26
 mysql-8.0.27   8.0.27
 mysql-8.0.28   8.0.28
-mysql-8.0.28   8.0.29
-mysql-latest   8.0.29     
+mysql-8.0.29   8.0.29
+mysql-8.0.30   8.0.30
+mysql-latest   8.0.30     
 ```
 For a mapping of the Tanzu Operator version, with the corresponding instance version(s) supported with that Operator, review the table under [Software Component Versions](release-notes.html#components) in the release notes.
 
@@ -98,7 +98,7 @@ The Tanzu Operator supports two columns to help users identify upgrade actions f
       name: instance-7
     spec:
       mysqlVersion:
-        name: mysql-8.0.26
+        name: mysql-8.0.30
       ...
     ```
 

--- a/upgrade-instance.html.md.erb
+++ b/upgrade-instance.html.md.erb
@@ -37,8 +37,8 @@ NAME           DB VERSION
 mysql-8.0.27   8.0.27
 mysql-8.0.28   8.0.28
 mysql-8.0.29   8.0.29
-mysql-8.0.30   8.0.30
-mysql-latest   8.0.30     
+mysql-8.0.31   8.0.31
+mysql-latest   8.0.31
 ```
 For a mapping of the Tanzu Operator version, with the corresponding instance version(s) supported with that Operator, review the table under [Software Component Versions](release-notes.html#components) in the release notes.
 
@@ -98,7 +98,7 @@ The Tanzu Operator supports two columns to help users identify upgrade actions f
       name: instance-7
     spec:
       mysqlVersion:
-        name: mysql-8.0.30
+        name: mysql-8.0.31
       ...
     ```
 
@@ -124,4 +124,3 @@ The Tanzu Operator supports two columns to help users identify upgrade actions f
     The `UPDATE STATUS` column of the instance should display `NoUpdateRequired`. The `TANZU VERSION` should display the latest Operator.
     
     For instances requiring an update (`UPDATE STATUS`="UpdateRequired"), refer to [Updating an Instance](update-instance.html#update-instance).
-    


### PR DESCRIPTION
As part of 1.7.0 Release, we're removing support for mysql 8.0.26 and adding support for mysql 8.0.30