### PR TITLE
Number of HA Members

### DIFF
--- a/high-availability.html.md.erb
+++ b/high-availability.html.md.erb
@@ -125,7 +125,7 @@ To change a single-node instance into an HA instance:
 1. Open the YAML file that you created in step 4 of [Create a MySQL Instance](create-delete-mysql.html#create-instance)
    in _Creating and Deleting MySQL Instances_.
 
-2. Change the value of `spec.highAvailability.enabled` to `true` and save the file.
+2. Change the value of `spec.highAvailability.enabled` to `true` to obtain a three-member HA instance and save the file. To change the number of members in the HA instance, see [Change Number of Members in HA MySQL Instance](high-availability.html#configuring-ha).
 
 3. Apply the change and deploy the HA instance by running:
 
@@ -145,6 +145,18 @@ To change a single-node instance into an HA instance:
     ```
     mysql.with.sql.tanzu.vmware.com/mysql-sample created
     ``` 
+
+## <a id="configuring-ha"></a>  Change Number of Members in HA MySQL Instance
+* A high-availability instance can have 3, 5, 7, or 9 members.
+* The default number of members for an HA instance is 3.
+* The number of members can be scaled up but not down. 
+* MySQL supports a maximum of 9 members of a single replication group. An even number of members is not a best practice for maintaining quorum. See the MySQL documentation on [Network Partition and Loss of Quorum](https://dev.mysql.com/doc/refman/8.0/en/group-replication-network-partitioning.html)
+* To change the number of members in your HA instance, change the value of `spec.highAvailability.members`. 
+    ```
+    spec:
+      highAvailabillity:
+        members: 5
+    ```
 
 ## <a id="inspect-instance"></a>  Inspect an HA MySQL Instance
 

--- a/high-availability.html.md.erb
+++ b/high-availability.html.md.erb
@@ -150,8 +150,8 @@ To change a single-node instance into an HA instance:
 * A high-availability instance can have 3, 5, 7, or 9 members.
 * The default number of members for an HA instance is 3.
 * The number of members can be scaled up but not down. 
-* MySQL supports a maximum of 9 members of a single replication group. An even number of members is not a best practice for maintaining quorum. See the MySQL documentation on [Network Partition and Loss of Quorum](https://dev.mysql.com/doc/refman/8.0/en/group-replication-network-partitioning.html)
-* To change the number of members in your HA instance, change the value of `spec.highAvailability.members`. 
+* MySQL supports a maximum of 9 members of a single replication group. An even number of members is not a best practice for maintaining quorum. See the MySQL documentation on [Network Partition and Loss of Quorum](https://dev.mysql.com/doc/refman/8.0/en/group-replication-network-partitioning.html).
+* To change the number of members in your HA instance, change the value of `spec.highAvailability.members`: 
     ```
     spec:
       highAvailabillity:

--- a/property-reference-mysql.html.md.erb
+++ b/property-reference-mysql.html.md.erb
@@ -36,6 +36,7 @@ spec:
 #### Enable highly available cluster
 #  highAvailability:
 #    enabled: true
+#    members: 3
 
 #### Enable affinity
 #  databasePodConfig:
@@ -194,9 +195,15 @@ The name of the Kubernetes secret containing the TLS certificate and private key
 
 **`highAvailability.enabled: <boolean>`**<br />
 **Optional**<br />
-**Default**: false<br />
+**Default**: false, unless `highAvailability.members` is greater than 1<br />
 Whether the instance is a high-availability cluster (not single-node). After being set to `true`, it cannot be modified. For information about high availability, see [Configuring MySQL Instances for High Availability](high-availability.html).
 **Example**: true
+
+**`highAvailability.members: <int>`**<br />
+**Optional**<br />
+**Default**: 3 when `highAvailability.enabled` is `true`<br />
+Total number of members in the HA cluster. Can be 3, 5, 7, or 9. A value of 1 would be a single instance. An even number creates the potential for a split-brain scenario, which must be avoided. For information about HA members, see [Change Number of Members in HA MySQL Instance](high-availability.html#configuring-ha).
+**Example**: 5
 
 **`databasePodConfig.affinity: <corev1.Affinity>`**<br />
 **Optional**<br />


### PR DESCRIPTION
Add field for HA number of members

Add to Property Reference
Add section to Configuring HA
-should we change the link I've included?
-I think we should link to some further reading, but some of the best resources were blogs, and I thought it was best to only link to MySQL docs or similar. So I'm open to feedback on that choice
-Should I avoid the term 'split-brain' or use it and explain it better?

Authored-by: Ria Mahoney <mpatrice@vmware.com>

Name the branches to merge this change with or enter "None".
