### PR TITLE
[1.9.0] Update backups storage artifact path

### DIFF
--- a/backup-restore.html.md.erb
+++ b/backup-restore.html.md.erb
@@ -199,19 +199,19 @@ To set a schedule for automatic backups, create a MySQLBackupSchedule resource:
 MySQLBackup resources that are automatically generated as a result of a MySQLBackupSchedule are named
 `SCHEDULE-NAME-TIMESTAMP`.
 
-By default, <%= vars.product_short %> stores backup artifacts under the subfolder structure `yyyy > mm > dd`.
+By default, <%= vars.product_short %> stores backup artifacts under the subfolder structure `mysql-<instance-name>-<instance-uuid> / backups / yyyy / mm / dd /`.
 You can configure a custom path for backups so that backup artifacts are stored under the subfolder
-structure `CUSTOM-PATH > yyyy > mm > dd`.
+structure `CUSTOM-PATH / mysql-<instance-name>-<instance-uuid> / backups / yyyy / mm / dd`.
 
 Backup artifacts stored in the external blobstore are named `DATETIME-RANDOM_STRING-backup.xb`.
 
-For example, if a MySQLBackupSchedule name is `mysqlbackupschedule-sample`, the custom backup
+For example, a user has an instance called `sample-instance` with a UUID of `bf5398d1-c0fb-4459-a024-559e9855a2cd`. If a MySQLBackupSchedule name is `mysqlbackupschedule-sample`, the custom backup
 path is `my-backups/`, and a backup was taken on Thursday, December 10, 2020 at 8:51:03 PM GMT
 (timestamp `1607633463`), then:
 
 * The MySQLBackup resource on the Kubernetes cluster is named `mysqlbackupschedule-sample-1607633463`
 * The backup artifact in the external blobstore is named `20201210T205103-kzw54l-backup.xb`
-* The path to the artifact is `my-backups/2020/12/10/`.
+* The path to the artifact is `my-backups/mysql-sample-instance-bf5398d1-c0fb-4459-a024-559e9855a2cd/backups/2020/12/10/`.
 
 ### <a id="on-demand"></a> Perform an On-Demand Backup
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -68,6 +68,21 @@ The <%= vars.product_short %> releases support the components listed below:
      <strong>IMPORTANT:</strong> VMware does not support deployments that have been modified by adding layers to the packaged Docker images, or deployments that reference images other than the VMware MySQL Operator. VMware does not support changing the contents of the deployed containers and pods in any way.
  </p>
 
+## <a id="1-9-0"></a>  Version 1.9.0
+
+**Release Date: TBD**
+
+### <a id="19_supported_platforms"></a> Supported Platforms
+
+### <a id="19_features"></a> Features
+* The backup storage artifact path is changed from `yyyy/mm/dd/` to `mysql-<InstanceName>-<InstanceUUID>/backups/yyyy/mm/dd/`. The artifact itself continues to be named `<DATETIME>-<RANDOM_STRING>-backup.xb`. Refer to [Name and Location for Backup Artifacts](backup-restore.html#name-and-location)
+
+### <a id="19_resolved"></a> Resolved Issues
+
+### <a id="19_issues"></a> Known Issues
+
+### <a id="19_limits"></a> Limitations
+
 ## <a id="1-8-0"></a>  Version 1.8.0
 
 **Release Date: May 31st, 2023**

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -75,7 +75,7 @@ The <%= vars.product_short %> releases support the components listed below:
 ### <a id="19_supported_platforms"></a> Supported Platforms
 
 ### <a id="19_features"></a> Features
-* The backup storage artifact path is changed from `yyyy/mm/dd/` to `mysql-<InstanceName>-<InstanceUUID>/backups/yyyy/mm/dd/`. The artifact itself continues to be named `<DATETIME>-<RANDOM_STRING>-backup.xb`. Refer to [Name and Location for Backup Artifacts](backup-restore.html#name-and-location)
+* The backup storage artifact path is changed from `yyyy/mm/dd/` to `mysql-<InstanceName>-<InstanceUUID>/backups/yyyy/mm/dd/`. The artifact itself continues to be named `<DATETIME>-<RANDOM_STRING>-backup.xb`. Refer to [Name and Location for Backup Artifacts](backup-restore.html#name-and-location).
 
 ### <a id="19_resolved"></a> Resolved Issues
 


### PR DESCRIPTION
Change backup storage artifact path to match future binlog path

Start 1.9.0 Release Notes


[#185222215]

Name the branches to merge this change with or enter "None".
