### PR TITLE
[1.8.0] Clarify docs

### DIFF
--- a/configure-tls.html.md.erb
+++ b/configure-tls.html.md.erb
@@ -26,10 +26,19 @@ The MySQL Operator deploys the instances with TLS from the self-signed `ClusterI
 
 By default, the Operator will create a `ClusterIssuer` named `vmware-sql-with-mysql-operator-ca-certificate-clusterissuer` and will retrieve MySQL instance certificates issued via this resource. 
 
-To verify that your MySQL Operator is using the default settings, with no `ClusterIssuer` customization, use:
+To verify that your MySQL Operator is using the default settings, with no `ClusterIssuer` customization, fetch the helm values:
 
 ``` 
-helm --namespace=vmware-mysql-for-kubernetes-system get values vmware-sql-with-mysql-operator
+helm --namespace=OPERATOR-NAMESPACE get values RELEASE-NAME
+```
+where:
+  - `OPERATOR-NAMESPACE` is the namespace where the operator is installed
+  - `RELEASE-NAME` is the name of the release for the helm installation
+
+For example:
+
+```
+helm --namespace=vmware-mysql-for-kubernetes-system get values my-mysql-operator
 ```
 The output should be similar to:
 
@@ -78,20 +87,24 @@ Before you configure TLS using a custom CA authority, you must have access permi
 1. Verify that cert-manager was configured during [Installing the MySQL Operator](install-operator.html#vmware-network-prerequisites) prerequisites:
 
     ```
-    kubectl get all --namespace=cert-manager
+    kubectl get all --namespace=CERT-MANAGER-NAMESPACE
     ```
+    where `CERT-MANAGER-NAMESPACE` is the namespace where cert-manager is installed
 
 2. Create a Kubernetes Secret for the CA certificate. For example, create a `my-CA-secret.yaml` with values similar to:
 
     ```
+    apiVersion: v1
     kind: Secret
     metadata:
-        name: my-ca-certificate
-        namespace: cert-manager-namespace
+      name: my-ca-certificate
+      namespace: CERT-MANAGER-NAMESPACE
+    type: kubernetes.io/tls
     data:
       tls.crt: this is a CA public key
       tls.key: this is the CA private key
     ```
+    where `CERT-MANAGER-NAMESPACE` is the namespace where cert-manager is installed
 
     and apply with:
 
@@ -117,10 +130,10 @@ Before you configure TLS using a custom CA authority, you must have access permi
     apiVersion: cert-manager.io/v1
     kind: ClusterIssuer
     metadata:
-        name: my-ca-certificate-clusterissuer
+      name: my-ca-certificate-clusterissuer
     spec:
-        ca:
-         secretName: my-ca-certificate
+      ca:
+        secretName: my-ca-certificate
     ```
 
 4. Apply the Secret using:
@@ -131,17 +144,21 @@ Before you configure TLS using a custom CA authority, you must have access permi
 
     For certificate creation troubleshooting see the [cert-manager](https://cert-manager.io/docs/faq/troubleshooting/) documentation.
 
-5. For new VMware MySQL Operator customers, create the MySQL Operator and set it to use the custom TLS issuer by using a command similar to:
+5. Create or update the MySQL Operator to use the custom TLS issuer by using a command similar to:
 
     ```
-    helm install vmware-sql-with-mysql-operator ./vmware-sql-with-mysql-operator/ --set=certManagerClusterIssuerName=my-ca-certificate-clusterissuer
+    helm --namespace=OPERATOR-NAMESPACE upgrade --install RELEASE-NAME CHART --set=certManagerClusterIssuerName=my-ca-certificate-clusterissuer
+    ```
+    where:
+      - `OPERATOR-NAMESPACE` is the namespace where the operator is installed
+      - `RELEASE-NAME` is the name of the release for the helm installation
+      - `CHART` is a reference to the helm chart
+
+    For example:
+    ```
+    helm --namespace=vmware-mysql-for-kubernetes-system upgrade --install my-mysql-operator /tmp/vmware-sql-with-mysql-operator --set=certManagerClusterIssuerName=my-ca-certificate-clusterissuer
     ```
 
-    For existing VMware MySQL Operator customers, update the Operator using a command similar to:
-
-    ```
-    helm update vmware-sql-with-mysql-operator ./vmware-sql-with-mysql-operator/ --set=certManagerClusterIssuerName=my-ca-certificate-clusterissuer
-    ```
     <p class="note">
        <strong>Note:</strong> If you need to use more than one CA issuer, either see <a href="#explicitly-configure-instance-for-TLS">Explicitly Configure a MySQL instance for TLS</a> or run another MySQL Operator in a different Kubernetes cluster.
     </p>
@@ -149,8 +166,12 @@ Before you configure TLS using a custom CA authority, you must have access permi
 6. To verify the custom `ClusterIssuer` setup, use:
 
     ```
-    helm --namespace=vmware-mysql-for-kubernetes-system get values vmware-sql-with-mysql-operator
+    helm --namespace=OPERATOR-NAMESPACE get values RELEASE-NAME
     ```
+    where:
+      - `OPERATOR-NAMESPACE` is the namespace for the operator
+      - `RELEASE-NAME` is the name of the release for the helm installation
+
     ```
     USER-SUPPLIED VALUES:
     certManagerClusterIssuerName: my-ca-certificate-clusterissuer
@@ -222,11 +243,11 @@ see [Create TLS Secret with cert-manager](#using-cert-manager) below.
     For example:
 
     ``` 
-      kubectl -n my-namespace create secret generic mysql-tls-secret \
-          --type kubernetes.io/tls \
-          --from-file=tls.crt=/path/server.crt \
-          --from-file=tls.key=/path/server.key \
-          --from-file=ca.crt=/path/server_ca.crt
+    kubectl -n my-namespace create secret generic mysql-tls-secret \
+      --type kubernetes.io/tls \
+      --from-file=tls.crt=/path/server.crt \
+      --from-file=tls.key=/path/server.key \
+      --from-file=ca.crt=/path/server_ca.crt
     ``` 
 
 After completing the steps above, you add the secret to the instance by following the instructions

--- a/connecting-apps.html.md.erb
+++ b/connecting-apps.html.md.erb
@@ -158,6 +158,8 @@ This section assumes that the MySQL instance is named `mysql-sample` and is depl
       database: bitnami_wordpress
 
     extraEnvVars:
+    - name: "WORDPRESS_ENABLE_DATABASE_SSL"
+      value: "yes"
     - name: "WORDPRESS_DATABASE_SSL_CA_FILE"
       value: "/etc/mysql/tls/ca.crt"
 

--- a/install-operator.html.md.erb
+++ b/install-operator.html.md.erb
@@ -166,59 +166,50 @@ You can access and install <%=vars.product_name %> using two different methods:
 1. Create the Operator namespace: 
 
     ```
+    kubectl create namespace NAMESPACE
+    ```
+    where `NAMESPACE` is the name of a namespace where the following steps will create a docker-registry secret and install the operator.
+
+    For example:
+    ```
     kubectl create namespace vmware-mysql-for-kubernetes-system
     ```
-    where `vmware-mysql-for-kubernetes-system` is an example namespace.
     
 
 1. Create a `docker-registry` type secret to allow the Kubernetes cluster to authenticate with a private image registry, or the Tanzu Registry, so it can pull images. 
 
     <p class='note important'><strong>IMPORTANT:</strong> Re-run the commands below to create identical or equivalent secrets in every namespace in which users will create VMware MySQL instances</strong>, and replace the Operator namespace <code>vmware-mysql-for-kubernetes-system</code> by the instance namespace (e.g. <code>default</code>). </br>
     If these secrets are not created in the instance namespace, the users will receive "ImagePullBackOff" errors when creating instances, as their MySQL pods fail to pull instance images from the image registry.</p>
-    
-    These examples create a secret named `tanzu-image-registry` using Tanzu Registry, Harbor, or GCR. 
 
-    **Tanzu Registry**
-    
     ```
-    
-    kubectl create secret docker-registry tanzu-image-registry \
-        --docker-server=https://registry.tanzu.vmware.com/ \
-        --docker-username="${DOCKER_USERNAME}" \
-        --docker-password="${DOCKER_PASSWORD}" \
-        --namespace=vmware-mysql-for-kubernetes-system
+    kubectl create secret docker-registry <SECRET-NAME> \
+        --docker-server=<DOCKER-SERVER> \
+        --docker-username=<DOCKER-USERNAME> \
+        --docker-password=<DOCKER-PASSWORD> \
+        --namespace=<OPERATOR-NAMESPACE>
     ```
-    
-    **Harbor**
-    
-    ```
-    kubectl create secret docker-registry tanzu-image-registry \
-        --docker-server=${HARBOR_URL} \
-        --docker-username=${HARBOR_USER} \
-        --docker-password="${HARBOR_PASSWORD}" \
-        --namespace=vmware-mysql-for-kubernetes-system
-    ```
-    
-    **GCR**
-    
+    where:
+      - `SECRET-NAME` is the name of the secret. Choose `tanzu-image-registry` to match the default secret name used by the operator
+      - `DOCKER-SERVER` is the name of the server location for the registry
+      - `DOCKER-USERNAME` is the username for registry authentication
+      - `DOCKER-PASSWORD` is the password for registry authentication
+
+    For example:
     ```
     kubectl create secret docker-registry tanzu-image-registry \
-        --docker-server=https://gcr.io \
-        --docker-username=_json_key \
-        --docker-password="$(cat ~/key.json)" \
-        --namespace=vmware-mysql-for-kubernetes-system
+      --docker-server=registry.tanzu.vmware.com \
+      --docker-username=my-username \
+      --docker-password=my-password \
+      --namespace=vmware-mysql-for-kubernetes-system
     ```
-
-    For GKE information on how to obtain the `key.json` service account file, refer to [Creating service account credentials](https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform#step_3_create_service_account_credentials) in the GKE documentation.
-
 
 #### <a id="create-overrides"></a> Review the Operator Values
 
 The below Operator configuration files are in the helm chart directory `vmware-sql-with-mysql-operator`.
 
-- If you setup the VMware MySQL Operator via Tanzu Network Registry, `vmware-sql-with-mysql-operator` should be in the directory created when you ran `helm pull ...`.
+- If you setup the VMware MySQL Operator via Tanzu Network Registry, `vmware-sql-with-mysql-operator` should be in the `untardir` directory specified in the `helm pull ...` command.
 
-- If you setup the VMware MySQL Operator via a downloaded archive file, go to the directory of helm charts within the unpacked the archive file:
+- If you setup the VMware MySQL Operator via a downloaded archive file, go to the directory of helm charts within the unpacked archive file:
 
   ```
   cd mysql-for-kubernetes-*/charts
@@ -230,7 +221,7 @@ List the contents of the Operator helm chart directory `vmware-sql-with-mysql-op
 ```
 ls -F vmware-sql-with-mysql-operator
 ```
-You should see it contains config files and subdirectories:
+You should see the chart directory contains config files and subdirectories:
 ```
 Chart.yaml      crds/      templates/      values.schema.json      values.yaml
 ```
@@ -239,10 +230,11 @@ In most situations, the default values supplied in the Operator configuration fi
 
 However, you will need to create an Operator Values Override file to replace those values with your own if any of the following are true:
 
-* You deployed the VMware SQL with MySQL for Kubernetes images from a registry other than registry.tanzu.vmware.com.
-* You named your registry secret something other than the default `tanzu-image-registry` in <strong>Create Operator Namespace and Secrets</strong> above.
-* You want to allocate different CPU or memory resources for your Operator.
-* You want to specify an alternate default version for new MySQL instances.
+* You relocated the VMware SQL with MySQL for Kubernetes images to a custom private registry.
+* You named the registry secret something other than the default `tanzu-image-registry` in <strong>Create Operator Namespace and Secrets</strong> above.
+* You want to allocate specific CPU or memory resources for your Operator.
+* You want to specify your ClusterIssuer for generating TLS credentials for the databases
+* You want to disable the security context on pods
 
 Create an Operator Values Override file:
 
@@ -327,19 +319,40 @@ Create an Operator Values Override file:
 
     Use Helm to install the MySQL Operator in your Kubernetes cluster:
 
+    Without an override file:
     ``` 
-    helm install --wait my-mysql-operator /tmp/vmware-sql-with-mysql-operator/ \
-      --values=operator-values-overrides.yaml \
-      --namespace=vmware-mysql-for-kubernetes-system \
-      --create-namespace
-    ``` 
+    helm install <RELEASE-NAME> <CHART-DIR> \
+      -n <OPERATOR-NAMESPACE> \
+      --wait
+    ```
+
+    If you need to specify an override file:
+    ```
+    helm install <RELEASE-NAME> <CHART-DIR> \
+      -f <OVERRIDE-FILE> \
+      -n <OPERATOR-NAMESPACE> \
+      --wait
+    ```
 
     where:
-    * `--wait` flag waits for the Operator deployment to complete before any image installation starts
-    * `my-mysql-operator` is the custom name you provide for your MySQL Operator
-    * `/tmp/vmware-sql-with-mysql-operator/` is the location of the MySQL Operator helm chart
-    * `vmware-mysql-for-kubernetes-system` is the Operator namespace you created in [Create Operator Namespace and Secrets](#create-namespace-and-secrets)
-    * `operator-values-overrides.yaml` is the overrides file with your custom values, as per [Review the Operator Values](#create-overrides)
+      - `RELEASE-NAME` is the custom name you provide for your MySQL Operator
+      - `CHART-DIR` is the location of the MySQL Operator helm chart
+      - `OPERATOR-NAMESPACE` is the Operator namespace you created in [Create Operator Namespace and Secrets](#create-namespace-and-secrets)
+      - `OVERRIDE-FILE` is the override file with your custom values, as per [Review the Operator Values](#create-overrides)
+
+    For example:
+    ```
+    helm install my-mysql-operator /tmp/vmware-sql-with-mysql-operator \
+      -n vmware-mysql-for-kubernetes-system \
+      --wait
+    ```
+
+    Or another example where the chart reference is an OCI registry name instead of a downloaded directory:
+    ```
+    helm install my-mysql-operator oci://registry.tanzu.vmware.com/tanzu-mysql-for-kubernetes/vmware-sql-with-mysql-operator --version 1.8.0 \
+      -n vmware-mysql-for-kubernetes-system \
+      --wait
+    ```
 
     The command displays a message similar to:
 
@@ -355,12 +368,18 @@ Create an Operator Values Override file:
        <strong>Note:</strong> Install the Operator in the same namespace as the secrets, as described in <a href="#create-namespace-and-secrets">Create Operator Namespace and Secrets</a>.
     </p>
 
-1.  If you used an Operator values override file, save it for future Operator upgrades reference. By default, Helm will re-apply those override values when you later use `helm upgrade`, unless you perform the upgrade with a different overrides file or with the `--reset-values` flag. For more details on Helm upgrades, see [Helm Upgrade](https://helm.sh/docs/helm/helm_upgrade/) in the Helm documentation.
+1.  If you used an Operator values override file, save it for future Operator upgrades reference. By default, Helm will re-apply those override values when you later use `helm upgrade`, unless you perform the upgrade with a different override file or with the `--reset-values` flag. For more details on Helm upgrades, see [Helm Upgrade](https://helm.sh/docs/helm/helm_upgrade/) in the Helm documentation.
 
 1.  Use `watch kubectl get all` to monitor the progress of the deployment. The deployment is complete when the MySQL Operator pod status changes to `Running`.
 
     ``` 
-    watch kubectl get all --namespace=vmware-mysql-for-kubernetes-system
+    watch kubectl get all -n <OPERATOR-NAMESPACE>
+    ```
+    where`OPERATOR-NAMESPACE` is the namespace where the operator is installed
+
+    For example:
+    ```
+    watch kubectl get all -n vmware-mysql-for-kubernetes-system
     ```
     The output would be similar to: 
     
@@ -381,12 +400,19 @@ Create an Operator Values Override file:
     You may also check the logs to confirm the Operator is running properly:
 
     ``` 
-    kubectl logs -n vmware-mysql-for-kubernetes-system -l app.kubernetes.io/name=tanzu-sql-with-mysql-operator
-    ``` 
+    kubectl logs -n <OPERATOR-NAMESPACE> -l app.kubernetes.io/name=tanzu-sql-with-mysql-operator
+    ```
+    where`OPERATOR-NAMESPACE` is the namespace where the operator is installed
     
-1. Clean up the temporary directory if you no longer need the exported chart:
+1. Clean up the downloaded chart if it is no longer needed:
 	```
-	rm -rf ${CHART_DIR}
+	rm -rf <CHART-DIR>
+	```
+	where `CHART-DIR` is the directory of the downloaded helm chart
+
+	For example:
+	```
+	rm -rf /tmp/vmware-sql-with-mysql-operator
 	```
 
 ## <a id="tanzu_cli_install"></a> Installing using the Tanzu CLI

--- a/upgrade-operator.html.md.erb
+++ b/upgrade-operator.html.md.erb
@@ -16,9 +16,9 @@ Ensure you have access to [Tanzu Network](https://network.tanzu.vmware.com) and 
     <strong>Note:</strong> Use Helm CLI 3.8.0 and later.
  </p>
 
-### <a id="access"></a> Access the Resources
+### <a id="access"></a> Download the helm chart
 
-You can access and install the new VMware MySQL Operator using any of the two different methods used during the initial installation.
+You can download the new VMware MySQL Operator using any of the two different methods used during the initial installation.
 
 - Use [Setup the VMware MySQL Operator via Tanzu Network Registry](install-operator.html#install-via-tanzu) for a faster installation process, and if your server hosts have access to the internet.
 
@@ -29,13 +29,14 @@ You can access and install the new VMware MySQL Operator using any of the two di
 
 After downloading the Helm chart, upgrade the operator following these steps:
 
-1. Set the environment variable `CHART_DIR` to the location of the downloaded helm chart. 
+1. Identify where the chart is downloaded.
 
 1. Update the existing VMware MySQL Operator Custom Resource Definitions (CRDs) with the new values:
 
     ```
-    kubectl apply -f ${CHART_DIR}/crds/
+    kubectl apply -f <CHART-DIR>/crds/
     ```
+    where `CHART-DIR` is the path to the downloaded helm chart.
 
 1. Update an existing overrides file or create an `operator_overrides_values.yaml` file at a location of your choice. 
 Refer to [Review the Operator Values](install-operator.html#create-overrides) for details on setting the appropriate overrides.
@@ -44,17 +45,10 @@ Refer to [Review the Operator Values](install-operator.html#create-overrides) fo
 then Helm will re-apply those override values to this upgrade, unless you perform the upgrade with other overrides or 
 with the `--reset-values` flag. See [Helm Upgrade documentation](https://helm.sh/docs/helm/helm_upgrade/) for details.
 
-1. Target the namespace where you installed the Helm release:
+1. Identify the name and namespace of the helm installation
 
     ```
-    kubectl config set-context --current --namespace=<MYSQL-OPERATOR-NAMESPACE>
-    ```
-    where `MYSQL-OPERATOR-NAMESPACE` is the namespace where the previous operator version is installed.
-
-    List the Helm releases using:
-    
-    ```
-    helm ls
+    helm ls -A
     ```
     ```
     NAME                NAMESPACE                           REVISION	UPDATED                             	STATUS  	CHART                              	  APP VERSION
@@ -64,11 +58,30 @@ with the `--reset-values` flag. See [Helm Upgrade documentation](https://helm.sh
 1. Upgrade the Operator using:
 
     ```
-    helm upgrade <RELEASE-NAME> ${CHART_DIR} -f /<path-to-your-file>/operator_overrides_values.yaml --wait
+    helm upgrade <RELEASE-NAME> <CHART-DIR> \
+      -n <OPERATOR-NAMESPACE> \
+      --wait
+    ```
+
+    If you need to specify an override file:
+    ```
+    helm upgrade <RELEASE-NAME> <CHART-DIR> \
+      -f <OVERRIDE-FILE> \
+      -n <OPERATOR-NAMESPACE> \
+      --wait
     ```
     where:
-     - `RELEASE-NAME` is the Helm release value under the `NAME` column of the list output
-     - `operator_overrides_values.yaml` is the overrides file
+      - `RELEASE-NAME` is the Helm release value under the `NAME` column of the list output
+      - `CHART-DIR` is the location of the MySQL Operator helm chart
+      - `OPERATOR-NAMESPACE` is the namespace where the operator is installed
+      - `OVERRIDE-FILE` is the path to the override file
+
+    For example:
+    ```
+    helm upgrade my-mysql-operator /tmp/vmware-sql-with-mysql-operator \
+      -n vmware-mysql-for-kubernetes-system \
+      --wait
+    ```
 
     The output is similar to:
 
@@ -84,10 +97,16 @@ with the `--reset-values` flag. See [Helm Upgrade documentation](https://helm.sh
     where `REVISION` is a counter for the number of Operator upgrades you have performed. If you have upgraded from 1.0 to 1.1, and from 1.1 to 1.2, the REVISION number would be 3.
 
 
-1. Clean up the temporary directory if it is no longer needed with the exported chart by running:
-	  ```
-	  rm -rf ${CHART_DIR}
-	  ```
+1. Clean up the downloaded chart if it is no longer needed:
+	 ```
+	 rm -rf <CHART-DIR>
+	 ```
+	 where `CHART-DIR` is the directory of the downloaded helm chart
+
+	 For example:
+	 ```
+	 rm -rf /tmp/vmware-sql-with-mysql-operator
+	 ```
 
 ## <a id="tanzu-upgrade"></a>Upgrading the Operator using the Tanzu CLI
 


### PR DESCRIPTION
We could backport this further (e.g. 1.7).

Summary:
- Fix wordpress example 
- Avoid hardcoded values and use placeholders in more steps for install/upgrade flow and explain the meaning of the placeholders
