### PR TITLE
Add link to custom config page to the TOC

### DIFF
--- a/toc.md
+++ b/toc.md
@@ -10,6 +10,7 @@
 * [Upgrading Instances](./upgrade-instance.html)
 * [Accessing Instances](./accessing.html)
 * [Configuring High Availability](./high-availability.html)
+* [Configuring MySQL Server](./configure-mysql-server.html)
 * [Monitoring Instances](./monitoring.html)
 * [Configuring TLS](./configure-tls.html)
 * [Rotating MySQL Credentials](./rotating-credentials.html)


### PR DESCRIPTION
Add custom-config page to table of contents

In our last release, we added custom configuration.
We added a page with instructions, and linked to it in the release notes.
But we failed to include Custom Config in the TOC on the left panel.
This commit fixes that

Authored-by: Ria Mahoney <mpatrice@vmware.com>

@dyozie Could we merge this with 1.9.0? And then merge into Main?
It needed to be published with the 1.9 release, and now it needs to be in main with the rest of 1.9
Thank you