### PR TITLE
Fixing links per bug 3294761

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -15,8 +15,8 @@ database.
 <%= vars.product_short %> packages a collection of open-source software to deploy
 and manage one or more instances of the MySQL database. It includes the following components:
 
-  * [Percona Server 8.0](https://www.percona.com/software/mysql-database/percona-server)
-  * [Percona XtraBackup 8.0](https://www.percona.com/software/mysql-database/percona-xtrabackup)
+  * [Percona Server 8.0](https://www.percona.com/mysql/software/percona-server-for-mysql)
+  * [Percona XtraBackup 8.0](https://www.percona.com/mysql/software)
 
 The major features of <%= vars.product_short %> include:
 


### PR DESCRIPTION
Branch 1.4.

Fixes to broken links per https://bugzilla.eng.vmware.com/show_bug.cgi?id=3294761#c2 in the https://docs.vmware.com/en/VMware-SQL-with-MySQL-for-Kubernetes/1.4/vmware-mysql-k8s/index.html topic.
