### PR TITLE
Update configmap example to valid mysql cnf format

### DIFF
--- a/configure-mysql-server.html.md.erb
+++ b/configure-mysql-server.html.md.erb
@@ -76,8 +76,8 @@ Use the following steps to customize your MySQL server configuration:
     data:
       my.cnf: |
         [mysqld]
-        max_connections: 250
-        slow_query_log: "on"
+        max_connections=250
+        slow_query_log=on
     ```
 
    <p class="note">The ConfigMap must have the key `my.cnf`.</p>


### PR DESCRIPTION
The configmap sample was not working because the my.cnf contents were not in the correct format. This commit corrects that format.
